### PR TITLE
Add dynamic about and services content management

### DIFF
--- a/backend/createtable.sql
+++ b/backend/createtable.sql
@@ -94,7 +94,46 @@ CREATE TABLE IF NOT EXISTS appointments (
 ) ENGINE=InnoDB;
 
 -- ---------------------------
--- 7. Create Indexes for Performance
+-- 7. Create the site_content table
+-- ---------------------------
+CREATE TABLE IF NOT EXISTS site_content (
+    ContentKey VARCHAR(100) PRIMARY KEY,
+    ContentValue LONGTEXT NOT NULL,
+    UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- ---------------------------
+-- 8. Create the service_packages table
+-- ---------------------------
+CREATE TABLE IF NOT EXISTS service_packages (
+    PackageID INT AUTO_INCREMENT PRIMARY KEY,
+    PackageName VARCHAR(255) NOT NULL,
+    Subtitle VARCHAR(255) NULL,
+    OriginalPrice DECIMAL(10,2) NOT NULL DEFAULT 0,
+    DiscountedPrice DECIMAL(10,2) NOT NULL DEFAULT 0,
+    SortOrder INT NOT NULL DEFAULT 0,
+    CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+-- ---------------------------
+-- 9. Create the service_package_items table
+-- ---------------------------
+CREATE TABLE IF NOT EXISTS service_package_items (
+    PackageItemID INT AUTO_INCREMENT PRIMARY KEY,
+    PackageID INT NOT NULL,
+    ItemName VARCHAR(255) NOT NULL,
+    ItemPrice DECIMAL(10,2) NOT NULL DEFAULT 0,
+    SortOrder INT NOT NULL DEFAULT 0,
+    CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (PackageID) REFERENCES service_packages(PackageID)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+-- ---------------------------
+-- 10. Create Indexes for Performance
 -- ---------------------------
 CREATE INDEX idx_patients_email ON patients(Email);
 CREATE INDEX idx_users_role ON users(Role);
@@ -103,7 +142,7 @@ CREATE INDEX idx_appointments_doctor_id ON appointments(DoctorID);
 CREATE INDEX idx_available_time_doctor_id ON available_time(DoctorID);
 
 -- ---------------------------
--- 8. Seed baseline reference data
+-- 11. Seed baseline reference data
 -- ---------------------------
 INSERT INTO doctors (FullName, MaxPatientNumber, CurrentPatientNumber)
 SELECT 'Dr. John Smith', 100, 0 FROM dual
@@ -122,7 +161,668 @@ SELECT 'System Administrator' FROM dual
 WHERE NOT EXISTS (SELECT 1 FROM admins WHERE FullName = 'System Administrator');
 
 -- ---------------------------
--- 9. Seed role-based authentication accounts
+-- 12. Seed marketing content (about & service packages)
+-- ---------------------------
+INSERT INTO site_content (ContentKey, ContentValue)
+SELECT 'about_page', JSON_OBJECT(
+    'hero', JSON_OBJECT(
+        'eyebrow', 'Who We Are',
+        'title', 'Destination Health, where compassionate care meets innovation',
+        'subtitle', 'Partnering with families across Bangladesh for healthier tomorrows.',
+        'description', 'Destination Health is a multidisciplinary medical network that blends expert clinicians, modern diagnostics, and digital experiences to keep every patient informed and supported.',
+        'stats', JSON_ARRAY(
+            JSON_OBJECT('label', 'Patients cared for annually', 'value', '45K+'),
+            JSON_OBJECT('label', 'Specialist physicians', 'value', '120+'),
+            JSON_OBJECT('label', 'Satisfaction rating', 'value', '98%')
+        )
+    ),
+    'sections', JSON_ARRAY(
+        JSON_OBJECT(
+            'title', 'Our Mission',
+            'body', 'We are dedicated to making healthcare simple, proactive, and relationship driven. Every appointment, lab visit, and follow-up is coordinated to give patients confidence in their care journey.'
+        ),
+        JSON_OBJECT(
+            'title', 'Comprehensive services under one roof',
+            'bullets', JSON_ARRAY(
+                'Family medicine, cardiology, neurology, oncology, and more.',
+                'Modern diagnostic imaging, pathology, and remote consultations.',
+                'Secure digital records with instant access for patients and providers.'
+            )
+        ),
+        JSON_OBJECT(
+            'title', 'How we support our community',
+            'body', 'From preventive screenings to long-term disease management, our teams coordinate personalized care plans that respect each person’s culture, goals, and lifestyle.'
+        ),
+        JSON_OBJECT(
+            'title', 'Technology that amplifies human care',
+            'bullets', JSON_ARRAY(
+                'Online appointment scheduling with real-time availability.',
+                'Automated reminders and follow-up care coordination.',
+                'Telehealth options that extend our reach beyond the hospital walls.'
+            )
+        )
+    ),
+    'callout', JSON_OBJECT(
+        'title', 'Ready to experience coordinated care?',
+        'description', 'Join Destination Health to access a dedicated care team, same-day diagnostics, and a medical partner that listens first.'
+    )
+)
+WHERE NOT EXISTS (SELECT 1 FROM site_content WHERE ContentKey = 'about_page');
+
+INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+SELECT 'Package-1', 'Essential wellness screening', 7710, 5900, 1
+WHERE NOT EXISTS (SELECT 1 FROM service_packages WHERE PackageName = 'Package-1');
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Complete Blood Count (CBC)', 400, 0
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Complete Blood Count (CBC)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Random Blood Sugar', 200, 1
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Random Blood Sugar'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Lipid Profile (Random)', 1400, 2
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Lipid Profile (Random)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Grouping & RH Factor', 300, 3
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Grouping & RH Factor'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Creatinine', 400, 4
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Creatinine'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HBsAg', 1000, 5
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HBsAg'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Urine R/E', 400, 6
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Urine R/E'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ECG', 400, 7
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ECG'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Digital X-Ray of Chest P/A View (Digital)', 600, 8
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Digital X-Ray of Chest P/A View (Digital)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Ultrasonography of Whole Abdomen', 2500, 9
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Ultrasonography of Whole Abdomen'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Needle, Tube & Reg. Charges', 110, 10
+FROM service_packages p
+WHERE p.PackageName = 'Package-1'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
+  );
+
+INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+SELECT 'Package-2', 'Advanced metabolic assessment', 14030, 10650, 2
+WHERE NOT EXISTS (SELECT 1 FROM service_packages WHERE PackageName = 'Package-2');
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Complete Blood Count (CBC)', 400, 0
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Complete Blood Count (CBC)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Sugar (Fasting & 2 hrs ABF)', 400, 1
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Sugar (Fasting & 2 hrs ABF)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HbA1c', 1400, 2
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HbA1c'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Lipid Profile (Fasting)', 1400, 3
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Lipid Profile (Fasting)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Liver Function Test', 1000, 4
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Liver Function Test'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Creatinine', 400, 5
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Creatinine'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Uric Acid', 600, 6
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Uric Acid'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Electrolytes', 1000, 7
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Electrolytes'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'TSH', 1000, 8
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'TSH'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HBsAg', 1000, 9
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HBsAg'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'PSA', 1400, 10
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'PSA'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Urine R/E', 400, 11
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Urine R/E'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ECG', 400, 12
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ECG'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Digital X-Ray of Chest P/A View (Digital)', 600, 13
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Digital X-Ray of Chest P/A View (Digital)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Ultrasonography of Whole Abdomen', 2500, 14
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Ultrasonography of Whole Abdomen'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Needle, Tube & Reg. Charges', 130, 15
+FROM service_packages p
+WHERE p.PackageName = 'Package-2'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
+  );
+
+INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+SELECT 'Package-3', 'Balanced health profile', 9410, 7180, 3
+WHERE NOT EXISTS (SELECT 1 FROM service_packages WHERE PackageName = 'Package-3');
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Complete Blood Count (CBC)', 400, 0
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Complete Blood Count (CBC)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Sugar (Fasting & 2 hrs ABF)', 400, 1
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Sugar (Fasting & 2 hrs ABF)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Lipid Profile (Fasting)', 1400, 2
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Lipid Profile (Fasting)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Grouping & RH Factor', 300, 3
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Grouping & RH Factor'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HBsAg', 1000, 4
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HBsAg'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'SGPT', 500, 5
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'SGPT'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Bilirubin (Total)', 400, 6
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Bilirubin (Total)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Uric Acid', 600, 7
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Uric Acid'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Creatinine', 400, 8
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Creatinine'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Urine R/E', 400, 9
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Urine R/E'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ECG', 400, 10
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ECG'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Digital X-Ray of Chest P/A View (Digital)', 600, 11
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Digital X-Ray of Chest P/A View (Digital)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Ultrasonography of Whole Abdomen', 2500, 12
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Ultrasonography of Whole Abdomen'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Needle, Tube & Reg. Charges', 110, 13
+FROM service_packages p
+WHERE p.PackageName = 'Package-3'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
+  );
+
+INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+SELECT 'Package-4', 'Women’s comprehensive screening', 16930, 12850, 4
+WHERE NOT EXISTS (SELECT 1 FROM service_packages WHERE PackageName = 'Package-4');
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Complete Blood Count (CBC)', 400, 0
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Complete Blood Count (CBC)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Sugar (Fasting & 2 hrs ABF)', 400, 1
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Sugar (Fasting & 2 hrs ABF)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HbA1c', 1400, 2
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HbA1c'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Lipid Profile (Fasting)', 1400, 3
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Lipid Profile (Fasting)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Liver Function Test', 1000, 4
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Liver Function Test'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Creatinine', 400, 5
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Creatinine'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Uric Acid', 600, 6
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Uric Acid'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Serum Electrolytes', 1000, 7
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Serum Electrolytes'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'TSH', 1000, 8
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'TSH'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HBsAg', 1000, 9
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HBsAg'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Pap Smear', 1200, 10
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Pap Smear'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Urine R/E', 400, 11
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Urine R/E'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ECG', 400, 12
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ECG'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Digital X-Ray of Chest P/A View (Digital)', 600, 13
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Digital X-Ray of Chest P/A View (Digital)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Mammography of Both Breast', 3000, 14
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Mammography of Both Breast'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Ultrasonography of Whole Abdomen', 2500, 15
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Ultrasonography of Whole Abdomen'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Needle, Tube & Reg. Charges', 230, 16
+FROM service_packages p
+WHERE p.PackageName = 'Package-4'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
+  );
+
+INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+SELECT 'Package-5', 'For 40 years and above', 19130, 14630, 5
+WHERE NOT EXISTS (SELECT 1 FROM service_packages WHERE PackageName = 'Package-5');
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Complete Blood Count (CBC)', 400, 0
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Complete Blood Count (CBC)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Blood Sugar (Fasting & 2 hrs ABF)', 400, 1
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Blood Sugar (Fasting & 2 hrs ABF)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HbA1c', 1400, 2
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HbA1c'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Lipid Profile (Fasting)', 1400, 3
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Lipid Profile (Fasting)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Liver Function Test (SGPT, Alkaline Phosphar, S.Bilirubin)', 1000, 4
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Liver Function Test (SGPT, Alkaline Phosphar, S.Bilirubin)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Kidney Function Test (S.Creatinine, S.Urea, Electrolytes)', 1900, 5
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Kidney Function Test (S.Creatinine, S.Urea, Electrolytes)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'C-Reactive Protein', 600, 6
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'C-Reactive Protein'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'TSH', 1000, 7
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'TSH'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'HBsAg', 1000, 8
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'HBsAg'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Urine R/E', 400, 9
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Urine R/E'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ECG', 400, 10
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ECG'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Digital X-Ray of Chest P/A View (Digital)', 600, 11
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Digital X-Ray of Chest P/A View (Digital)'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Colour Doppler Echo', 3000, 12
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Colour Doppler Echo'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'ETT', 3000, 13
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'ETT'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Ultrasonography of Whole Abdomen', 2500, 14
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Ultrasonography of Whole Abdomen'
+  );
+
+INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+SELECT p.PackageID, 'Needle, Tube & Reg. Charges', 130, 15
+FROM service_packages p
+WHERE p.PackageName = 'Package-5'
+  AND NOT EXISTS (
+    SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
+  );
+
+-- ---------------------------
+-- 13. Seed role-based authentication accounts
 -- ---------------------------
 INSERT INTO users (Email, PasswordHash, Role, AdminID)
 SELECT 'admin@hospital.com', '$2a$10$D5s70fBDZ1.6vQrPYC0.AuBZGAPll7n/eI16oQ4GhWG0V6h78trKC', 'admin', a.AdminID
@@ -145,7 +845,7 @@ WHERE NOT EXISTS (
 );
 
 -- ---------------------------
--- 10. Triggers to maintain doctor patient counts
+-- 14. Triggers to maintain doctor patient counts
 -- ---------------------------
 DELIMITER //
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,7 @@ const doctorRoutes = require('./routes/doctorRoutes');
 const patientRoutes = require('./routes/patientRoutes');
 const appointmentRoutes = require('./routes/appointmentRoutes');
 const adminRoutes = require('./routes/adminRoutes');
+const contentRoutes = require('./routes/contentRoutes');
 const errorHandler = require('./middleware/errorHandler');
 
 // Create and configure the Express application instance.
@@ -28,6 +29,7 @@ app.use('/api/doctors', doctorRoutes);
 app.use('/api/patients', patientRoutes);
 app.use('/api/appointments', appointmentRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/content', contentRoutes);
 
 // Fallback handler for unmatched routes to avoid Express default HTML responses.
 app.use((req, res) => {

--- a/backend/src/controllers/adminContentController.js
+++ b/backend/src/controllers/adminContentController.js
@@ -1,0 +1,63 @@
+const {
+  getAboutContent,
+  updateAboutContent,
+  getServicePackages,
+  createServicePackage,
+  updateServicePackage,
+  deleteServicePackage,
+} = require('../services/contentService');
+
+async function fetchAboutContent(_req, res) {
+  const content = await getAboutContent();
+  res.json(content);
+}
+
+async function saveAboutContent(req, res) {
+  const updated = await updateAboutContent(req.body);
+  res.json(updated);
+}
+
+async function fetchServicePackages(_req, res) {
+  const packages = await getServicePackages();
+  res.json(packages);
+}
+
+async function createPackage(req, res) {
+  const created = await createServicePackage(req.body);
+  res.status(201).json(created);
+}
+
+async function updatePackage(req, res) {
+  const { id } = req.params;
+  const packageId = Number.parseInt(id, 10);
+  if (Number.isNaN(packageId)) {
+    const error = new Error('Invalid package identifier.');
+    error.status = 400;
+    throw error;
+  }
+
+  const updated = await updateServicePackage(packageId, req.body);
+  res.json(updated);
+}
+
+async function deletePackage(req, res) {
+  const { id } = req.params;
+  const packageId = Number.parseInt(id, 10);
+  if (Number.isNaN(packageId)) {
+    const error = new Error('Invalid package identifier.');
+    error.status = 400;
+    throw error;
+  }
+
+  await deleteServicePackage(packageId);
+  res.status(204).send();
+}
+
+module.exports = {
+  fetchAboutContent,
+  saveAboutContent,
+  fetchServicePackages,
+  createPackage,
+  updatePackage,
+  deletePackage,
+};

--- a/backend/src/controllers/contentController.js
+++ b/backend/src/controllers/contentController.js
@@ -1,0 +1,16 @@
+const { getAboutContent, getServicePackages } = require('../services/contentService');
+
+async function fetchAboutContent(_req, res) {
+  const content = await getAboutContent();
+  res.json(content);
+}
+
+async function fetchServicePackages(_req, res) {
+  const packages = await getServicePackages();
+  res.json(packages);
+}
+
+module.exports = {
+  fetchAboutContent,
+  fetchServicePackages,
+};

--- a/backend/src/database/schema.js
+++ b/backend/src/database/schema.js
@@ -10,7 +10,12 @@ async function ensureSchema() {
   await createUsersTable();
   await createAvailabilityTable();
   await createAppointmentsTable();
+  await createSiteContentTable();
+  await createServicePackagesTable();
+  await createServicePackageItemsTable();
   await seedDoctors();
+  await seedSiteContent();
+  await seedServicePackages();
   await migrateMissingPatientUsers();
   await seedAdminUser();
   await seedDoctorUsers();
@@ -115,6 +120,48 @@ async function createAppointmentsTable() {
   );
 }
 
+async function createSiteContentTable() {
+  await execute(
+    `CREATE TABLE IF NOT EXISTS site_content (
+      ContentKey VARCHAR(100) PRIMARY KEY,
+      ContentValue LONGTEXT NOT NULL,
+      UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    )`
+  );
+}
+
+async function createServicePackagesTable() {
+  await execute(
+    `CREATE TABLE IF NOT EXISTS service_packages (
+      PackageID INT PRIMARY KEY AUTO_INCREMENT,
+      PackageName VARCHAR(255) NOT NULL,
+      Subtitle VARCHAR(255) NULL,
+      OriginalPrice DECIMAL(10, 2) NOT NULL DEFAULT 0,
+      DiscountedPrice DECIMAL(10, 2) NOT NULL DEFAULT 0,
+      SortOrder INT NOT NULL DEFAULT 0,
+      CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    )`
+  );
+}
+
+async function createServicePackageItemsTable() {
+  await execute(
+    `CREATE TABLE IF NOT EXISTS service_package_items (
+      PackageItemID INT PRIMARY KEY AUTO_INCREMENT,
+      PackageID INT NOT NULL,
+      ItemName VARCHAR(255) NOT NULL,
+      ItemPrice DECIMAL(10, 2) NOT NULL DEFAULT 0,
+      SortOrder INT NOT NULL DEFAULT 0,
+      CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      FOREIGN KEY (PackageID) REFERENCES service_packages(PackageID)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+    )`
+  );
+}
+
 async function seedDoctors() {
   const [{ count }] = await execute('SELECT COUNT(*) AS count FROM doctors');
   if (count > 0) {
@@ -186,6 +233,214 @@ async function seedDoctorUsers() {
         `INSERT INTO users (Email, PasswordHash, Role, DoctorID)
          VALUES (?, ?, 'doctor', ?)`,
         [email, passwordHash, doctor.DoctorID]
+      );
+    })
+  );
+}
+
+async function seedSiteContent() {
+  const existing = await execute('SELECT ContentKey FROM site_content WHERE ContentKey = ?', ['about_page']);
+  if (existing.length > 0) {
+    return;
+  }
+
+  const aboutContent = {
+    hero: {
+      eyebrow: 'Who We Are',
+      title: 'Destination Health, where compassionate care meets innovation',
+      subtitle: 'Partnering with families across Bangladesh for healthier tomorrows.',
+      description:
+        'Destination Health is a multidisciplinary medical network that blends expert clinicians, modern diagnostics, and digital experiences to keep every patient informed and supported.',
+      stats: [
+        { label: 'Patients cared for annually', value: '45K+' },
+        { label: 'Specialist physicians', value: '120+' },
+        { label: 'Satisfaction rating', value: '98%' },
+      ],
+    },
+    sections: [
+      {
+        title: 'Our Mission',
+        body:
+          'We are dedicated to making healthcare simple, proactive, and relationship driven. Every appointment, lab visit, and follow-up is coordinated to give patients confidence in their care journey.',
+      },
+      {
+        title: 'Comprehensive services under one roof',
+        bullets: [
+          'Family medicine, cardiology, neurology, oncology, and more.',
+          'Modern diagnostic imaging, pathology, and remote consultations.',
+          'Secure digital records with instant access for patients and providers.',
+        ],
+      },
+      {
+        title: 'How we support our community',
+        body:
+          'From preventive screenings to long-term disease management, our teams coordinate personalized care plans that respect each person’s culture, goals, and lifestyle.',
+      },
+      {
+        title: 'Technology that amplifies human care',
+        bullets: [
+          'Online appointment scheduling with real-time availability.',
+          'Automated reminders and follow-up care coordination.',
+          'Telehealth options that extend our reach beyond the hospital walls.',
+        ],
+      },
+    ],
+    callout: {
+      title: 'Ready to experience coordinated care?',
+      description:
+        'Join Destination Health to access a dedicated care team, same-day diagnostics, and a medical partner that listens first.',
+    },
+  };
+
+  await execute(
+    `INSERT INTO site_content (ContentKey, ContentValue)
+     VALUES (?, ?)`,
+    ['about_page', JSON.stringify(aboutContent)]
+  );
+}
+
+async function seedServicePackages() {
+  const [{ count }] = await execute('SELECT COUNT(*) AS count FROM service_packages');
+  if (count > 0) {
+    return;
+  }
+
+  const packages = [
+    {
+      name: 'Package-1',
+      subtitle: 'Essential wellness screening',
+      discountedPrice: 5900,
+      sortOrder: 1,
+      items: [
+        { name: 'Complete Blood Count (CBC)', price: 400 },
+        { name: 'Random Blood Sugar', price: 200 },
+        { name: 'Lipid Profile (Random)', price: 1400 },
+        { name: 'Blood Grouping & RH Factor', price: 300 },
+        { name: 'Serum Creatinine', price: 400 },
+        { name: 'HBsAg', price: 1000 },
+        { name: 'Urine R/E', price: 400 },
+        { name: 'ECG', price: 400 },
+        { name: 'Digital X-Ray of Chest P/A View (Digital)', price: 600 },
+        { name: 'Ultrasonography of Whole Abdomen', price: 2500 },
+        { name: 'Needle, Tube & Reg. Charges', price: 110 },
+      ],
+    },
+    {
+      name: 'Package-2',
+      subtitle: 'Advanced metabolic assessment',
+      discountedPrice: 10650,
+      sortOrder: 2,
+      items: [
+        { name: 'Complete Blood Count (CBC)', price: 400 },
+        { name: 'Blood Sugar (Fasting & 2 hrs ABF)', price: 400 },
+        { name: 'HbA1c', price: 1400 },
+        { name: 'Lipid Profile (Fasting)', price: 1400 },
+        { name: 'Liver Function Test', price: 1000 },
+        { name: 'Serum Creatinine', price: 400 },
+        { name: 'Serum Uric Acid', price: 600 },
+        { name: 'Serum Electrolytes', price: 1000 },
+        { name: 'TSH', price: 1000 },
+        { name: 'HBsAg', price: 1000 },
+        { name: 'PSA', price: 1400 },
+        { name: 'Urine R/E', price: 400 },
+        { name: 'ECG', price: 400 },
+        { name: 'Digital X-Ray of Chest P/A View (Digital)', price: 600 },
+        { name: 'Ultrasonography of Whole Abdomen', price: 2500 },
+        { name: 'Needle, Tube & Reg. Charges', price: 130 },
+      ],
+    },
+    {
+      name: 'Package-3',
+      subtitle: 'Balanced health profile',
+      discountedPrice: 7180,
+      sortOrder: 3,
+      items: [
+        { name: 'Complete Blood Count (CBC)', price: 400 },
+        { name: 'Blood Sugar (Fasting & 2 hrs ABF)', price: 400 },
+        { name: 'Lipid Profile (Fasting)', price: 1400 },
+        { name: 'Blood Grouping & RH Factor', price: 300 },
+        { name: 'HBsAg', price: 1000 },
+        { name: 'SGPT', price: 500 },
+        { name: 'Serum Bilirubin (Total)', price: 400 },
+        { name: 'Serum Uric Acid', price: 600 },
+        { name: 'Serum Creatinine', price: 400 },
+        { name: 'Urine R/E', price: 400 },
+        { name: 'ECG', price: 400 },
+        { name: 'Digital X-Ray of Chest P/A View (Digital)', price: 600 },
+        { name: 'Ultrasonography of Whole Abdomen', price: 2500 },
+        { name: 'Needle, Tube & Reg. Charges', price: 110 },
+      ],
+    },
+    {
+      name: 'Package-4',
+      subtitle: 'Women’s comprehensive screening',
+      discountedPrice: 12850,
+      sortOrder: 4,
+      items: [
+        { name: 'Complete Blood Count (CBC)', price: 400 },
+        { name: 'Blood Sugar (Fasting & 2 hrs ABF)', price: 400 },
+        { name: 'HbA1c', price: 1400 },
+        { name: 'Lipid Profile (Fasting)', price: 1400 },
+        { name: 'Liver Function Test', price: 1000 },
+        { name: 'Serum Creatinine', price: 400 },
+        { name: 'Serum Uric Acid', price: 600 },
+        { name: 'Serum Electrolytes', price: 1000 },
+        { name: 'TSH', price: 1000 },
+        { name: 'HBsAg', price: 1000 },
+        { name: 'Pap Smear', price: 1200 },
+        { name: 'Urine R/E', price: 400 },
+        { name: 'ECG', price: 400 },
+        { name: 'Digital X-Ray of Chest P/A View (Digital)', price: 600 },
+        { name: 'Mammography of Both Breast', price: 3000 },
+        { name: 'Ultrasonography of Whole Abdomen', price: 2500 },
+        { name: 'Needle, Tube & Reg. Charges', price: 230 },
+      ],
+    },
+    {
+      name: 'Package-5',
+      subtitle: 'For 40 years and above',
+      discountedPrice: 14630,
+      sortOrder: 5,
+      items: [
+        { name: 'Complete Blood Count (CBC)', price: 400 },
+        { name: 'Blood Sugar (Fasting & 2 hrs ABF)', price: 400 },
+        { name: 'HbA1c', price: 1400 },
+        { name: 'Lipid Profile (Fasting)', price: 1400 },
+        { name: 'Liver Function Test (SGPT, Alkaline Phosphar, S.Bilirubin)', price: 1000 },
+        { name: 'Kidney Function Test (S.Creatinine, S.Urea, Electrolytes)', price: 1900 },
+        { name: 'C-Reactive Protein', price: 600 },
+        { name: 'TSH', price: 1000 },
+        { name: 'HBsAg', price: 1000 },
+        { name: 'Urine R/E', price: 400 },
+        { name: 'ECG', price: 400 },
+        { name: 'Digital X-Ray of Chest P/A View (Digital)', price: 600 },
+        { name: 'Colour Doppler Echo', price: 3000 },
+        { name: 'ETT', price: 3000 },
+        { name: 'Ultrasonography of Whole Abdomen', price: 2500 },
+        { name: 'Needle, Tube & Reg. Charges', price: 130 },
+      ],
+    },
+  ];
+
+  await Promise.all(
+    packages.map(async (pkg, pkgIndex) => {
+      const total = pkg.items.reduce((sum, item) => sum + Number(item.price), 0);
+      const result = await execute(
+        `INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+         VALUES (?, ?, ?, ?, ?)`,
+        [pkg.name, pkg.subtitle, total, pkg.discountedPrice, pkg.sortOrder ?? pkgIndex]
+      );
+
+      const packageId = result.insertId;
+
+      await Promise.all(
+        pkg.items.map((item, itemIndex) =>
+          execute(
+            `INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+             VALUES (?, ?, ?, ?)`,
+            [packageId, item.name, item.price, itemIndex]
+          )
+        )
       );
     })
   );

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -3,9 +3,53 @@ const asyncHandler = require('../utils/asyncHandler');
 const authenticateToken = require('../middleware/authenticate');
 const authorizeRoles = require('../middleware/authorizeRoles');
 const { getOverview } = require('../controllers/adminController');
+const {
+  fetchAboutContent,
+  saveAboutContent,
+  fetchServicePackages,
+  createPackage,
+  updatePackage,
+  deletePackage,
+} = require('../controllers/adminContentController');
 
 const router = Router();
 
 router.get('/overview', authenticateToken, authorizeRoles('admin'), asyncHandler(getOverview));
+router.get(
+  '/content/about',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(fetchAboutContent)
+);
+router.put(
+  '/content/about',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(saveAboutContent)
+);
+router.get(
+  '/content/service-packages',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(fetchServicePackages)
+);
+router.post(
+  '/content/service-packages',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(createPackage)
+);
+router.put(
+  '/content/service-packages/:id',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(updatePackage)
+);
+router.delete(
+  '/content/service-packages/:id',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(deletePackage)
+);
 
 module.exports = router;

--- a/backend/src/routes/contentRoutes.js
+++ b/backend/src/routes/contentRoutes.js
@@ -1,0 +1,10 @@
+const { Router } = require('express');
+const asyncHandler = require('../utils/asyncHandler');
+const { fetchAboutContent, fetchServicePackages } = require('../controllers/contentController');
+
+const router = Router();
+
+router.get('/about', asyncHandler(fetchAboutContent));
+router.get('/service-packages', asyncHandler(fetchServicePackages));
+
+module.exports = router;

--- a/backend/src/services/contentService.js
+++ b/backend/src/services/contentService.js
@@ -1,0 +1,302 @@
+const { execute, transaction } = require('../database/query');
+
+function parseJSON(value, fallback = {}) {
+  if (!value) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return fallback;
+  }
+}
+
+function normalizeStrings(value) {
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeAboutContent(content = {}) {
+  const hero = content.hero || {};
+  const sections = Array.isArray(content.sections) ? content.sections : [];
+  const callout = content.callout || {};
+
+  return {
+    hero: {
+      eyebrow: normalizeStrings(hero.eyebrow),
+      title: normalizeStrings(hero.title),
+      subtitle: normalizeStrings(hero.subtitle),
+      description: normalizeStrings(hero.description),
+      stats: Array.isArray(hero.stats)
+        ? hero.stats.map((stat) => ({
+            label: normalizeStrings(stat.label),
+            value: normalizeStrings(stat.value),
+          }))
+        : [],
+    },
+    sections: sections.map((section) => ({
+      title: normalizeStrings(section.title),
+      body: normalizeStrings(section.body),
+      bullets: Array.isArray(section.bullets)
+        ? section.bullets
+            .map((item) => normalizeStrings(item))
+            .filter((item) => item.length > 0)
+        : [],
+    })),
+    callout: {
+      title: normalizeStrings(callout.title),
+      description: normalizeStrings(callout.description),
+    },
+  };
+}
+
+async function getAboutContent() {
+  const rows = await execute('SELECT ContentValue FROM site_content WHERE ContentKey = ?', ['about_page']);
+  if (!rows.length) {
+    return normalizeAboutContent();
+  }
+
+  return normalizeAboutContent(parseJSON(rows[0].ContentValue));
+}
+
+async function updateAboutContent(content) {
+  const normalized = normalizeAboutContent(content);
+
+  await execute(
+    `INSERT INTO site_content (ContentKey, ContentValue)
+     VALUES (?, ?)
+     ON DUPLICATE KEY UPDATE ContentValue = VALUES(ContentValue), UpdatedAt = CURRENT_TIMESTAMP`,
+    ['about_page', JSON.stringify(normalized)]
+  );
+
+  return normalized;
+}
+
+function normalizePackagePayload(payload = {}) {
+  const items = Array.isArray(payload.items) ? payload.items : [];
+
+  const sanitizedItems = items
+    .map((item) => ({
+      id: item.id || item.packageItemId || item.PackageItemID || null,
+      name: normalizeStrings(item.name || item.ItemName),
+      price: Math.max(0, Number.parseFloat(item.price ?? item.ItemPrice ?? 0) || 0),
+    }))
+    .filter((item) => item.name.length > 0);
+
+  const rawSortOrder =
+    payload.sortOrder !== undefined && payload.sortOrder !== null
+      ? payload.sortOrder
+      : payload.SortOrder !== undefined && payload.SortOrder !== null
+      ? payload.SortOrder
+      : 0;
+
+  return {
+    id: payload.id || payload.packageId || payload.PackageID || null,
+    name: normalizeStrings(payload.name || payload.PackageName),
+    subtitle: normalizeStrings(payload.subtitle || payload.Subtitle),
+    discountedPrice: Math.max(0, Number.parseFloat(payload.discountedPrice ?? payload.DiscountedPrice ?? 0) || 0),
+    sortOrder: Number.parseInt(rawSortOrder, 10) || 0,
+    items: sanitizedItems,
+  };
+}
+
+function transformPackageRow(row, packageItems) {
+  const items = packageItems.map((item) => ({
+    id: item.PackageItemID,
+    name: item.ItemName,
+    price: Number.parseFloat(item.ItemPrice),
+    sortOrder: item.SortOrder,
+  }));
+
+  const totalPrice = items.reduce((sum, item) => sum + Number(item.price), 0);
+  const discountedRaw = Number.parseFloat(row.DiscountedPrice);
+  const discounted = Number.isNaN(discountedRaw) ? 0 : discountedRaw;
+  const originalRaw = Number.parseFloat(row.OriginalPrice);
+  const originalPrice = Number.isNaN(originalRaw) ? totalPrice : originalRaw;
+
+  return {
+    id: row.PackageID,
+    name: row.PackageName,
+    subtitle: row.Subtitle || '',
+    totalPrice,
+    originalPrice,
+    discountedPrice: discounted,
+    savings: Number((totalPrice - discounted).toFixed(2)),
+    sortOrder: row.SortOrder,
+    items: items.sort((a, b) => a.sortOrder - b.sortOrder || a.id - b.id),
+  };
+}
+
+async function getServicePackages() {
+  const packages = await execute(
+    `SELECT PackageID, PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder
+     FROM service_packages
+     ORDER BY SortOrder ASC, PackageID ASC`
+  );
+
+  if (!packages.length) {
+    return [];
+  }
+
+  const packageIds = packages.map((pkg) => pkg.PackageID);
+  const packageItems = await execute(
+    `SELECT PackageItemID, PackageID, ItemName, ItemPrice, SortOrder
+     FROM service_package_items
+     WHERE PackageID IN (?)
+     ORDER BY SortOrder ASC, PackageItemID ASC`,
+    [packageIds]
+  );
+
+  return packages.map((pkg) => {
+    const items = packageItems.filter((item) => item.PackageID === pkg.PackageID);
+    return transformPackageRow(pkg, items);
+  });
+}
+
+async function getServicePackageById(packageId) {
+  const packages = await execute(
+    `SELECT PackageID, PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder
+     FROM service_packages
+     WHERE PackageID = ?`,
+    [packageId]
+  );
+
+  const pkg = packages[0];
+  if (!pkg) {
+    return null;
+  }
+
+  const items = await execute(
+    `SELECT PackageItemID, PackageID, ItemName, ItemPrice, SortOrder
+     FROM service_package_items
+     WHERE PackageID = ?
+     ORDER BY SortOrder ASC, PackageItemID ASC`,
+    [packageId]
+  );
+
+  return transformPackageRow(pkg, items);
+}
+
+async function createServicePackage(payload) {
+  const normalized = normalizePackagePayload(payload);
+
+  if (!normalized.name) {
+    const error = new Error('Package name is required.');
+    error.status = 400;
+    throw error;
+  }
+
+  if (!normalized.items.length) {
+    const error = new Error('At least one service item is required.');
+    error.status = 400;
+    throw error;
+  }
+
+  return transaction(async (connection) => {
+    const totalPrice = normalized.items.reduce((sum, item) => sum + Number(item.price), 0);
+
+    const [result] = await connection.execute(
+      `INSERT INTO service_packages (PackageName, Subtitle, OriginalPrice, DiscountedPrice, SortOrder)
+       VALUES (?, ?, ?, ?, ?)`,
+      [normalized.name, normalized.subtitle, totalPrice, normalized.discountedPrice, normalized.sortOrder]
+    );
+
+    const packageId = result.insertId;
+
+    await Promise.all(
+      normalized.items.map((item, index) =>
+        connection.execute(
+          `INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+           VALUES (?, ?, ?, ?)`,
+          [packageId, item.name, item.price, index]
+        )
+      )
+    );
+
+    return packageId;
+  }).then((packageId) => getServicePackageById(packageId));
+}
+
+async function updateServicePackage(packageId, payload) {
+  const normalized = normalizePackagePayload(payload);
+
+  if (!normalized.name) {
+    const error = new Error('Package name is required.');
+    error.status = 400;
+    throw error;
+  }
+
+  if (!normalized.items.length) {
+    const error = new Error('At least one service item is required.');
+    error.status = 400;
+    throw error;
+  }
+
+  return transaction(async (connection) => {
+    const [existingRows] = await connection.execute(
+      'SELECT PackageItemID FROM service_package_items WHERE PackageID = ?',
+      [packageId]
+    );
+    const existingItemIds = existingRows.map((row) => row.PackageItemID);
+
+    const totalPrice = normalized.items.reduce((sum, item) => sum + Number(item.price), 0);
+
+    await connection.execute(
+      `UPDATE service_packages
+       SET PackageName = ?, Subtitle = ?, OriginalPrice = ?, DiscountedPrice = ?, SortOrder = ?
+       WHERE PackageID = ?`,
+      [normalized.name, normalized.subtitle, totalPrice, normalized.discountedPrice, normalized.sortOrder, packageId]
+    );
+
+    const retainedIds = new Set();
+
+    for (let index = 0; index < normalized.items.length; index += 1) {
+      const item = normalized.items[index];
+      if (item.id && existingItemIds.includes(item.id)) {
+        await connection.execute(
+          `UPDATE service_package_items
+           SET ItemName = ?, ItemPrice = ?, SortOrder = ?
+           WHERE PackageItemID = ? AND PackageID = ?`,
+          [item.name, item.price, index, item.id, packageId]
+        );
+        retainedIds.add(item.id);
+      } else {
+        const [result] = await connection.execute(
+          `INSERT INTO service_package_items (PackageID, ItemName, ItemPrice, SortOrder)
+           VALUES (?, ?, ?, ?)`,
+          [packageId, item.name, item.price, index]
+        );
+        retainedIds.add(result.insertId);
+      }
+    }
+
+    const idsToDelete = existingItemIds.filter((id) => !retainedIds.has(id));
+    if (idsToDelete.length > 0) {
+      await connection.execute(
+        `DELETE FROM service_package_items WHERE PackageItemID IN (?)`,
+        [idsToDelete]
+      );
+    }
+
+    return packageId;
+  }).then((updatedId) => getServicePackageById(updatedId));
+}
+
+async function deleteServicePackage(packageId) {
+  const result = await execute('DELETE FROM service_packages WHERE PackageID = ?', [packageId]);
+  if (result.affectedRows === 0) {
+    const error = new Error('Service package not found.');
+    error.status = 404;
+    throw error;
+  }
+}
+
+module.exports = {
+  getAboutContent,
+  updateAboutContent,
+  getServicePackages,
+  getServicePackageById,
+  createServicePackage,
+  updateServicePackage,
+  deleteServicePackage,
+};

--- a/frontend/src/pages/AboutUs.jsx
+++ b/frontend/src/pages/AboutUs.jsx
@@ -1,75 +1,157 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
-const sections = [
-  {
-    title: 'What is the Doctor’s Portal?',
-    content:
-      'The Doctor’s Portal is a modern healthcare management system that makes healthcare more accessible and organized. It allows patients to easily register, choose their family doctor, book appointments online, and manage their health records — all in one secure place.',
-  },
-  {
-    title: 'Key Features',
-    list: [
-      { heading: 'Patient Registration', text: 'New patients can sign up quickly and securely.' },
-      { heading: 'Doctor Management', text: 'Each patient is assigned to a family doctor with a maximum patient capacity.' },
-      { heading: 'Appointment Booking', text: 'Patients can view available time slots and book appointments instantly.' },
-      { heading: 'Upcoming Appointments', text: 'Patients can view their upcoming visits in an organized schedule.' },
-      { heading: 'Appointment History', text: 'Past consultations are recorded for reference and follow-ups.' },
-      { heading: 'Secure Authentication', text: 'Encrypted login ensures data privacy and security.' },
-    ],
-  },
-  {
-    title: 'Our Mission',
-    content:
-      'We aim to simplify healthcare management by reducing wait times, removing paperwork, and providing patients with an easy-to-use digital system for booking and managing their appointments. At the same time, we empower doctors with tools to organize their schedules and manage patient loads efficiently.',
-  },
-  {
-    title: 'Technology Stack',
-    list: [
-      { heading: 'Frontend', text: 'React.js for a dynamic and user-friendly interface.' },
-      { heading: 'Backend', text: 'Node.js + Express.js for APIs and business logic.' },
-      { heading: 'Database', text: 'MySQL/MariaDB for secure data storage.' },
-      { heading: 'Authentication', text: 'JWT (JSON Web Tokens) with bcrypt for password security.' },
-    ],
-  },
-  {
-    title: 'Why Choose Us?',
-    content:
-      'Healthcare should be simple, fast, and secure. Our Doctor’s Portal bridges the gap between patients and doctors, offering an efficient and reliable way to manage appointments and patient-doctor relationships.',
-  },
-];
+const apiBaseUrl = process.env.REACT_APP_API_URL;
 
 function AboutUs() {
+  const [content, setContent] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchContent = async () => {
+      setLoading(true);
+      setError('');
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/content/about`);
+
+        if (!response.ok) {
+          throw new Error('Unable to load the about page details.');
+        }
+
+        const data = await response.json();
+        setContent(data);
+      } catch (err) {
+        setError(err.message || 'An unexpected error occurred while loading the page.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchContent();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-slate-600">
+        Loading Destination Health story...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-red-600">
+        {error}
+      </div>
+    );
+  }
+
+  const hero = content?.hero ?? {};
+  const sections = Array.isArray(content?.sections) ? content.sections : [];
+  const callout = content?.callout ?? {};
+
   return (
-    <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-2 text-slate-800">
-      <section className="rounded-3xl bg-gradient-to-tr from-brand-primary via-sky-500 to-brand-accent px-6 py-12 text-center text-white shadow-2xl">
-        <h1 className="text-3xl font-semibold sm:text-4xl">About Our Doctor’s Portal</h1>
-        <p className="mt-3 text-base text-sky-100 sm:text-lg">
-          Connecting patients and doctors with ease and simplicity.
-        </p>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 pb-16 pt-4 text-slate-800 sm:px-6 lg:px-8">
+      <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-gradient-to-br from-brand-primary via-sky-500 to-brand-accent px-6 py-12 text-white shadow-2xl">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.25),transparent_55%)]" aria-hidden="true" />
+        <div className="relative z-10 flex flex-col gap-6 text-left md:flex-row md:items-end md:justify-between">
+          <div className="max-w-2xl space-y-4">
+            {hero.eyebrow ? (
+              <span className="inline-flex items-center rounded-full bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-white">
+                {hero.eyebrow}
+              </span>
+            ) : null}
+            <div className="space-y-3">
+              <h1 className="text-3xl font-semibold leading-tight sm:text-4xl lg:text-5xl">{hero.title}</h1>
+              {hero.subtitle ? <p className="text-lg text-emerald-100 sm:text-xl">{hero.subtitle}</p> : null}
+              {hero.description ? <p className="text-sm text-emerald-50 sm:text-base">{hero.description}</p> : null}
+            </div>
+          </div>
+          {Array.isArray(hero.stats) && hero.stats.length > 0 ? (
+            <dl className="grid min-w-[16rem] gap-4 rounded-2xl border border-white/30 bg-white/10 p-6 text-left text-sm">
+              {hero.stats.map((stat) => (
+                <div key={`${stat.label}-${stat.value}`} className="flex flex-col">
+                  <dt className="text-xs uppercase tracking-wide text-emerald-100">{stat.label}</dt>
+                  <dd className="text-2xl font-semibold text-white">{stat.value}</dd>
+                </div>
+              ))}
+            </dl>
+          ) : null}
+        </div>
       </section>
 
-      {sections.map((section) => (
-        <section
-          key={section.title}
-          className="rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur"
-        >
-          <h2 className="text-xl font-semibold text-brand-primary">
-            {section.title}
-          </h2>
-          {section.content ? (
-            <p className="mt-3 text-sm leading-relaxed text-slate-700 sm:text-base">{section.content}</p>
-          ) : (
-            <ul className="mt-3 space-y-2 text-sm leading-relaxed text-slate-700 sm:text-base">
-              {section.list.map((item) => (
-                <li key={item.heading} className="flex flex-col gap-1">
-                  <span className="font-semibold text-brand-primary">{item.heading}:</span>
-                  <span>{item.text}</span>
-                </li>
-              ))}
-            </ul>
-          )}
+      <section className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
+        <article className="rounded-3xl border border-slate-200 bg-white/95 p-8 shadow-xl backdrop-blur">
+          <h2 className="text-2xl font-semibold text-brand-primary">Our commitment to care</h2>
+          <p className="mt-4 text-base leading-relaxed text-slate-700">
+            Destination Health reimagines how families experience healthcare. We coordinate specialists, diagnostics, and
+            digital tools so that every appointment feels connected, compassionate, and clear.
+          </p>
+          <p className="mt-3 text-base leading-relaxed text-slate-700">
+            From preventive wellness plans to urgent consultations, your care team is designed around you—making it easier to
+            stay ahead of every milestone.
+          </p>
+        </article>
+
+        <article className="flex flex-col gap-4 rounded-3xl border border-brand-primary/30 bg-brand-primary/5 p-8 shadow-lg">
+          <h3 className="text-xl font-semibold text-brand-primary">Patient-first philosophy</h3>
+          <p className="text-base leading-relaxed text-slate-700">
+            We believe in healthcare that listens first, uses data responsibly, and keeps communities thriving through
+            education and early intervention.
+          </p>
+          <ul className="mt-2 space-y-2 text-sm text-slate-600">
+            <li className="flex items-start gap-2">
+              <span className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-brand-primary" aria-hidden="true" />
+              Trusted specialists collaborating across departments
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-brand-primary" aria-hidden="true" />
+              Digital tools that simplify appointments and follow-ups
+            </li>
+            <li className="flex items-start gap-2">
+              <span className="mt-1 inline-block h-2.5 w-2.5 rounded-full bg-brand-primary" aria-hidden="true" />
+              Holistic plans tailored to your lifestyle and goals
+            </li>
+          </ul>
+        </article>
+      </section>
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {sections.map((section, index) => (
+          <article key={`${section.title}-${index}`} className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+            <h2 className="text-xl font-semibold text-brand-primary">{section.title}</h2>
+            {section.body ? <p className="text-sm leading-relaxed text-slate-700 sm:text-base">{section.body}</p> : null}
+            {Array.isArray(section.bullets) && section.bullets.length > 0 ? (
+              <ul className="space-y-2 text-sm text-slate-600 sm:text-base">
+                {section.bullets.map((bullet, bulletIndex) => (
+                  <li key={`${section.title}-${bulletIndex}`} className="flex items-start gap-2">
+                    <span className="mt-2 inline-block h-1.5 w-1.5 rounded-full bg-brand-primary" aria-hidden="true" />
+                    <span>{bullet}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      {callout?.title || callout?.description ? (
+        <section className="overflow-hidden rounded-3xl border border-brand-dark/20 bg-brand-dark px-6 py-10 text-white shadow-xl">
+          <div className="flex flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+            <div className="space-y-2">
+              <h2 className="text-2xl font-semibold sm:text-3xl">{callout.title}</h2>
+              {callout.description ? <p className="text-base text-emerald-100 sm:text-lg">{callout.description}</p> : null}
+            </div>
+            <a
+              href="/services"
+              className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-brand-dark shadow-soft transition hover:bg-emerald-100"
+            >
+              Explore our care packages
+            </a>
+          </div>
         </section>
-      ))}
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,114 +1,971 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { AuthContext } from '../AuthContext';
+
+const apiBaseUrl = process.env.REACT_APP_API_URL;
+
+const tabs = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'about', label: 'About Page' },
+  { id: 'packages', label: 'Service Packages' },
+];
+
+const createEmptyAboutDraft = () => ({
+  hero: { eyebrow: '', title: '', subtitle: '', description: '', stats: [] },
+  sections: [],
+  callout: { title: '', description: '' },
+});
+
+const deepClone = (value) => {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  return JSON.parse(JSON.stringify(value));
+};
+
+const mapPackageResponseToForm = (pkg) => ({
+  id: pkg.id ?? pkg.PackageID ?? null,
+  name: pkg.name ?? pkg.PackageName ?? '',
+  subtitle: pkg.subtitle ?? pkg.Subtitle ?? '',
+  discountedPrice: pkg.discountedPrice !== undefined ? pkg.discountedPrice.toString() : (pkg.totalPrice ?? '').toString(),
+  sortOrder: pkg.sortOrder !== undefined ? pkg.sortOrder.toString() : '0',
+  items: Array.isArray(pkg.items)
+    ? pkg.items.map((item) => ({
+        id: item.id ?? item.PackageItemID ?? null,
+        name: item.name ?? item.ItemName ?? '',
+        price: item.price !== undefined ? item.price.toString() : '0',
+      }))
+    : [],
+});
 
 function AdminDashboard() {
   const { auth } = useContext(AuthContext);
-  const [overview, setOverview] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState('');
   const role = auth.user?.role;
 
+  const [activeTab, setActiveTab] = useState('overview');
+
+  const [overview, setOverview] = useState(null);
+  const [overviewStatus, setOverviewStatus] = useState('idle');
+  const [overviewError, setOverviewError] = useState('');
+
+  const [aboutDraft, setAboutDraft] = useState(null);
+  const [aboutStatus, setAboutStatus] = useState('idle');
+  const [aboutError, setAboutError] = useState('');
+  const [aboutFeedback, setAboutFeedback] = useState(null);
+  const [aboutSaving, setAboutSaving] = useState(false);
+
+  const [packageDrafts, setPackageDrafts] = useState([]);
+  const [packagesStatus, setPackagesStatus] = useState('idle');
+  const [packagesError, setPackagesError] = useState('');
+  const [packageFeedback, setPackageFeedback] = useState(null);
+  const [packageSavingKey, setPackageSavingKey] = useState(null);
+  const [packageDeletingKey, setPackageDeletingKey] = useState(null);
+
+  const fetchOverview = useCallback(async () => {
+    if (!auth.token) {
+      return;
+    }
+
+    setOverviewStatus('loading');
+    setOverviewError('');
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/overview`, {
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to load dashboard metrics.');
+      }
+
+      const data = await response.json();
+      setOverview(data);
+      setOverviewStatus('succeeded');
+    } catch (err) {
+      setOverviewError(err.message || 'An unexpected error occurred while loading metrics.');
+      setOverviewStatus('failed');
+    }
+  }, [auth.token]);
+
+  const fetchAboutContent = useCallback(async () => {
+    if (!auth.token) {
+      return;
+    }
+
+    setAboutStatus('loading');
+    setAboutError('');
+    setAboutFeedback(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/content/about`, {
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to load the about page content.');
+      }
+
+      const data = await response.json();
+      const normalized = data && typeof data === 'object' ? data : createEmptyAboutDraft();
+      setAboutDraft(deepClone(normalized));
+      setAboutStatus('succeeded');
+    } catch (err) {
+      setAboutError(err.message || 'Failed to load about page content.');
+      setAboutStatus('failed');
+    }
+  }, [auth.token]);
+
+  const fetchPackages = useCallback(async () => {
+    if (!auth.token) {
+      return;
+    }
+
+    setPackagesStatus('loading');
+    setPackagesError('');
+    setPackageFeedback(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/content/service-packages`, {
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to load service packages.');
+      }
+
+      const data = await response.json();
+      const list = Array.isArray(data) ? data.map(mapPackageResponseToForm) : [];
+      setPackageDrafts(list);
+      setPackagesStatus('succeeded');
+    } catch (err) {
+      setPackagesError(err.message || 'Failed to load service packages.');
+      setPackagesStatus('failed');
+    }
+  }, [auth.token]);
+
   useEffect(() => {
-    const fetchOverview = async () => {
-      if (!auth.token) {
-        return;
-      }
+    if (!auth.token || role !== 'admin') {
+      return;
+    }
 
-      if (role !== 'admin') {
-        setError('Access restricted to administrator accounts.');
-        setLoading(false);
-        return;
-      }
+    if (activeTab === 'overview' && overviewStatus === 'idle') {
+      fetchOverview();
+    }
 
-      try {
-        const response = await fetch(`${process.env.REACT_APP_API_URL}/api/admin/overview`, {
-          headers: {
-            Authorization: `Bearer ${auth.token}`,
-          },
-        });
+    if (activeTab === 'about' && aboutStatus === 'idle') {
+      fetchAboutContent();
+    }
 
-        if (!response.ok) {
-          throw new Error('Unable to load dashboard metrics.');
-        }
-
-        const data = await response.json();
-        setOverview(data);
-      } catch (err) {
-        console.error(err);
-        setError(err.message || 'An unexpected error occurred.');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchOverview();
-  }, [auth.token, role]);
+    if (activeTab === 'packages' && packagesStatus === 'idle') {
+      fetchPackages();
+    }
+  }, [activeTab, auth.token, role, overviewStatus, aboutStatus, packagesStatus, fetchOverview, fetchAboutContent, fetchPackages]);
 
   const renderMetricCard = (title, value) => (
-    <div className="rounded-2xl border border-emerald-100 bg-white/90 p-6 shadow-soft">
+    <div className="rounded-2xl border border-emerald-100 bg-white/90 p-6 shadow-soft" key={title}>
       <p className="text-sm font-medium text-slate-500">{title}</p>
       <p className="mt-2 text-3xl font-semibold text-brand-primary">{value}</p>
     </div>
   );
 
-  if (loading) {
-    return <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-slate-600">Loading dashboard...</div>;
-  }
+  const handleHeroFieldChange = (field, value) => {
+    setAboutDraft((prev) => ({
+      ...(prev || createEmptyAboutDraft()),
+      hero: {
+        ...((prev && prev.hero) || createEmptyAboutDraft().hero),
+        [field]: value,
+      },
+    }));
+  };
 
-  if (error) {
-    return <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-red-600">{error}</div>;
+  const handleHeroStatChange = (index, field, value) => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const stats = Array.isArray(base.hero?.stats) ? [...base.hero.stats] : [];
+      stats[index] = { ...stats[index], [field]: value };
+      return {
+        ...base,
+        hero: {
+          ...base.hero,
+          stats,
+        },
+      };
+    });
+  };
+
+  const handleAddHeroStat = () => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const stats = Array.isArray(base.hero?.stats) ? [...base.hero.stats] : [];
+      stats.push({ label: '', value: '' });
+      return {
+        ...base,
+        hero: {
+          ...base.hero,
+          stats,
+        },
+      };
+    });
+  };
+
+  const handleRemoveHeroStat = (index) => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const stats = Array.isArray(base.hero?.stats) ? [...base.hero.stats] : [];
+      stats.splice(index, 1);
+      return {
+        ...base,
+        hero: {
+          ...base.hero,
+          stats,
+        },
+      };
+    });
+  };
+
+  const handleSectionFieldChange = (index, field, value) => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const sections = Array.isArray(base.sections) ? [...base.sections] : [];
+      sections[index] = {
+        ...sections[index],
+        [field]: value,
+      };
+      return {
+        ...base,
+        sections,
+      };
+    });
+  };
+
+  const handleSectionBulletsChange = (index, value) => {
+    const bullets = value
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+    handleSectionFieldChange(index, 'bullets', bullets);
+  };
+
+  const handleAddSection = () => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const sections = Array.isArray(base.sections) ? [...base.sections] : [];
+      sections.push({ title: '', body: '', bullets: [] });
+      return {
+        ...base,
+        sections,
+      };
+    });
+  };
+
+  const handleRemoveSection = (index) => {
+    setAboutDraft((prev) => {
+      const base = prev || createEmptyAboutDraft();
+      const sections = Array.isArray(base.sections) ? [...base.sections] : [];
+      sections.splice(index, 1);
+      return {
+        ...base,
+        sections,
+      };
+    });
+  };
+
+  const handleCalloutChange = (field, value) => {
+    setAboutDraft((prev) => ({
+      ...(prev || createEmptyAboutDraft()),
+      callout: {
+        ...((prev && prev.callout) || createEmptyAboutDraft().callout),
+        [field]: value,
+      },
+    }));
+  };
+
+  const handleSaveAbout = async (event) => {
+    event.preventDefault();
+    if (!aboutDraft || !auth.token) {
+      return;
+    }
+
+    setAboutSaving(true);
+    setAboutFeedback(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/content/about`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${auth.token}`,
+        },
+        body: JSON.stringify(aboutDraft),
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to save about page content.');
+      }
+
+      const updated = await response.json();
+      setAboutDraft(deepClone(updated));
+      setAboutFeedback({ type: 'success', message: 'About page updated successfully.' });
+    } catch (err) {
+      setAboutFeedback({ type: 'error', message: err.message || 'Failed to update about page.' });
+    } finally {
+      setAboutSaving(false);
+    }
+  };
+
+  const handlePackageFieldChange = (index, field, value) => {
+    setPackageDrafts((prev) => {
+      const next = [...prev];
+      next[index] = {
+        ...next[index],
+        [field]: value,
+      };
+      return next;
+    });
+  };
+
+  const handlePackageItemChange = (packageIndex, itemIndex, field, value) => {
+    setPackageDrafts((prev) => {
+      const next = [...prev];
+      const pkg = next[packageIndex];
+      const items = Array.isArray(pkg.items) ? [...pkg.items] : [];
+      items[itemIndex] = {
+        ...items[itemIndex],
+        [field]: value,
+      };
+      next[packageIndex] = {
+        ...pkg,
+        items,
+      };
+      return next;
+    });
+  };
+
+  const handleAddPackageItem = (packageIndex) => {
+    setPackageDrafts((prev) => {
+      const next = [...prev];
+      const pkg = next[packageIndex];
+      const items = Array.isArray(pkg.items) ? [...pkg.items] : [];
+      items.push({ id: null, name: '', price: '' });
+      next[packageIndex] = {
+        ...pkg,
+        items,
+      };
+      return next;
+    });
+  };
+
+  const handleRemovePackageItem = (packageIndex, itemIndex) => {
+    setPackageDrafts((prev) => {
+      const next = [...prev];
+      const pkg = next[packageIndex];
+      const items = Array.isArray(pkg.items) ? [...pkg.items] : [];
+      if (items.length <= 1) {
+        items[0] = { ...items[0], name: '', price: '' };
+      } else {
+        items.splice(itemIndex, 1);
+      }
+      next[packageIndex] = {
+        ...pkg,
+        items,
+      };
+      return next;
+    });
+  };
+
+  const buildPackagePayload = (pkg) => ({
+    name: (pkg.name || '').trim(),
+    subtitle: (pkg.subtitle || '').trim(),
+    discountedPrice: Number.parseFloat(pkg.discountedPrice) || 0,
+    sortOrder: Number.parseInt(pkg.sortOrder, 10) || 0,
+    items: (pkg.items || [])
+      .map((item) => ({
+        id: item.id || undefined,
+        name: (item.name || '').trim(),
+        price: Number.parseFloat(item.price) || 0,
+      }))
+      .filter((item) => item.name.length > 0),
+  });
+
+  const handleSavePackage = async (pkg, index) => {
+    if (!auth.token) {
+      return;
+    }
+
+    const payload = buildPackagePayload(pkg);
+    if (!payload.name) {
+      setPackageFeedback({ type: 'error', message: 'Package name is required.' });
+      return;
+    }
+
+    if (!payload.items.length) {
+      setPackageFeedback({ type: 'error', message: 'Add at least one package item before saving.' });
+      return;
+    }
+
+    const key = pkg.id ?? `new-${index}`;
+    setPackageSavingKey(key);
+    setPackageFeedback(null);
+
+    const endpoint = pkg.id
+      ? `${apiBaseUrl}/api/admin/content/service-packages/${pkg.id}`
+      : `${apiBaseUrl}/api/admin/content/service-packages`;
+
+    const method = pkg.id ? 'PUT' : 'POST';
+
+    try {
+      const response = await fetch(endpoint, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${auth.token}`,
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to save the service package.');
+      }
+
+      const result = await response.json();
+      setPackageDrafts((prev) => {
+        const next = [...prev];
+        next[index] = mapPackageResponseToForm(result);
+        return next;
+      });
+      setPackageFeedback({ type: 'success', message: `${result.name || 'Package'} saved successfully.` });
+    } catch (err) {
+      setPackageFeedback({ type: 'error', message: err.message || 'Failed to save package.' });
+    } finally {
+      setPackageSavingKey(null);
+    }
+  };
+
+  const handleDeletePackage = async (pkg, index) => {
+    if (!auth.token) {
+      return;
+    }
+
+    if (!pkg.id) {
+      setPackageDrafts((prev) => prev.filter((_, idx) => idx !== index));
+      setPackageFeedback({ type: 'success', message: 'Draft package removed.' });
+      return;
+    }
+
+    const confirmDelete = window.confirm(`Are you sure you want to remove ${pkg.name}?`);
+    if (!confirmDelete) {
+      return;
+    }
+
+    setPackageDeletingKey(pkg.id);
+    setPackageFeedback(null);
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/content/service-packages/${pkg.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('Unable to delete the service package.');
+      }
+
+      setPackageDrafts((prev) => prev.filter((_, idx) => idx !== index));
+      setPackageFeedback({ type: 'success', message: `${pkg.name} removed successfully.` });
+    } catch (err) {
+      setPackageFeedback({ type: 'error', message: err.message || 'Failed to delete package.' });
+    } finally {
+      setPackageDeletingKey(null);
+    }
+  };
+
+  const handleAddPackage = () => {
+    setPackageDrafts((prev) => [
+      ...prev,
+      {
+        id: null,
+        name: '',
+        subtitle: '',
+        discountedPrice: '',
+        sortOrder: (prev.length + 1).toString(),
+        items: [{ id: null, name: '', price: '' }],
+      },
+    ]);
+  };
+
+  const sortedPackageDrafts = useMemo(
+    () => [...packageDrafts].sort((a, b) => (Number.parseInt(a.sortOrder, 10) || 0) - (Number.parseInt(b.sortOrder, 10) || 0)),
+    [packageDrafts]
+  );
+
+  if (role !== 'admin') {
+    return (
+      <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-red-600">
+        Access restricted to administrator accounts.
+      </div>
+    );
   }
 
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 pb-12">
       <header className="text-center">
         <h1 className="text-3xl font-semibold text-slate-900">Admin Dashboard</h1>
-        <p className="mt-2 text-slate-600">Key metrics and recent activity across Destination Health.</p>
+        <p className="mt-2 text-slate-600">Manage operations, site content, and promotional packages from a single workspace.</p>
       </header>
 
-      <section className="grid gap-4 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur sm:grid-cols-2 lg:grid-cols-4">
-        {renderMetricCard('Total Patients', overview?.metrics?.totalPatients ?? 0)}
-        {renderMetricCard('Total Doctors', overview?.metrics?.totalDoctors ?? 0)}
-        {renderMetricCard('Appointments Booked', overview?.metrics?.totalAppointments ?? 0)}
-        {renderMetricCard('Upcoming Appointments', overview?.metrics?.upcomingAppointments ?? 0)}
-      </section>
+      <nav className="mx-auto flex flex-wrap justify-center gap-2">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={() => setActiveTab(tab.id)}
+            className={`rounded-full px-5 py-2 text-sm font-medium transition ${
+              activeTab === tab.id
+                ? 'bg-brand-primary text-white shadow-soft'
+                : 'border border-slate-200 bg-white text-slate-600 hover:border-brand-primary/50 hover:text-brand-primary'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </nav>
 
-      <section className="grid gap-6 lg:grid-cols-2">
-        <article className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
-          <h2 className="text-xl font-semibold text-brand-primary">Most Active Doctors</h2>
-          <ul className="mt-4 space-y-3 text-sm text-slate-700">
-            {overview?.topDoctors?.length ? (
-              overview.topDoctors.map((doctor) => (
-                <li key={doctor.DoctorID} className="flex items-center justify-between">
-                  <span>{doctor.FullName}</span>
-                  <span className="font-semibold text-brand-primary">
-                    {doctor.CurrentPatientNumber}/{doctor.MaxPatientNumber}
-                  </span>
-                </li>
-              ))
-            ) : (
-              <li className="text-slate-500">No doctor data available.</li>
-            )}
-          </ul>
-        </article>
+      {activeTab === 'overview' ? (
+        overviewStatus === 'loading' ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-slate-600">Loading dashboard...</div>
+        ) : overviewError ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-red-600">{overviewError}</div>
+        ) : (
+          <section className="flex flex-col gap-8">
+            <div className="grid gap-4 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur sm:grid-cols-2 lg:grid-cols-4">
+              {renderMetricCard('Total Patients', overview?.metrics?.totalPatients ?? 0)}
+              {renderMetricCard('Total Doctors', overview?.metrics?.totalDoctors ?? 0)}
+              {renderMetricCard('Appointments Booked', overview?.metrics?.totalAppointments ?? 0)}
+              {renderMetricCard('Upcoming Appointments', overview?.metrics?.upcomingAppointments ?? 0)}
+            </div>
 
-        <article className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
-          <h2 className="text-xl font-semibold text-brand-primary">Recent Patients</h2>
-          <ul className="mt-4 space-y-3 text-sm text-slate-700">
-            {overview?.recentPatients?.length ? (
-              overview.recentPatients.map((patient) => (
-                <li key={patient.PatientID} className="flex flex-col rounded-xl bg-slate-50 px-4 py-3">
-                  <span className="font-semibold text-slate-900">{patient.FullName}</span>
-                  <span className="text-slate-500">{patient.Email}</span>
-                  <span className="text-slate-500">{patient.PhoneNumber}</span>
-                </li>
-              ))
-            ) : (
-              <li className="text-slate-500">No recent patients found.</li>
-            )}
-          </ul>
-        </article>
-      </section>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <article className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+                <h2 className="text-xl font-semibold text-brand-primary">Most Active Doctors</h2>
+                <ul className="mt-4 space-y-3 text-sm text-slate-700">
+                  {overview?.topDoctors?.length ? (
+                    overview.topDoctors.map((doctor) => (
+                      <li key={doctor.DoctorID} className="flex items-center justify-between">
+                        <span>{doctor.FullName}</span>
+                        <span className="font-semibold text-brand-primary">
+                          {doctor.CurrentPatientNumber}/{doctor.MaxPatientNumber}
+                        </span>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-slate-500">No doctor data available.</li>
+                  )}
+                </ul>
+              </article>
+
+              <article className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+                <h2 className="text-xl font-semibold text-brand-primary">Recent Patients</h2>
+                <ul className="mt-4 space-y-3 text-sm text-slate-700">
+                  {overview?.recentPatients?.length ? (
+                    overview.recentPatients.map((patient) => (
+                      <li key={patient.PatientID} className="flex flex-col rounded-xl bg-slate-50 px-4 py-3">
+                        <span className="font-semibold text-slate-900">{patient.FullName}</span>
+                        <span className="text-slate-500">{patient.Email}</span>
+                        <span className="text-slate-500">{patient.PhoneNumber}</span>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="text-slate-500">No recent patients found.</li>
+                  )}
+                </ul>
+              </article>
+            </div>
+          </section>
+        )
+      ) : null}
+
+      {activeTab === 'about' ? (
+        aboutStatus === 'loading' ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-slate-600">Loading about page content...</div>
+        ) : aboutError ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-red-600">{aboutError}</div>
+        ) : (
+          <form
+            onSubmit={handleSaveAbout}
+            className="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur"
+          >
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-brand-primary">About page content</h2>
+                <p className="text-sm text-slate-600">Edit hero messaging, supporting sections, and the closing call-to-action.</p>
+              </div>
+              <button
+                type="submit"
+                disabled={aboutSaving}
+                className="inline-flex items-center justify-center rounded-full bg-brand-primary px-5 py-2 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-dark disabled:cursor-not-allowed disabled:bg-slate-400"
+              >
+                {aboutSaving ? 'Saving...' : 'Save changes'}
+              </button>
+            </header>
+
+            {aboutFeedback ? (
+              <div
+                className={`rounded-2xl border px-4 py-3 text-sm ${
+                  aboutFeedback.type === 'success'
+                    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                    : 'border-rose-200 bg-rose-50 text-rose-700'
+                }`}
+              >
+                {aboutFeedback.message}
+              </div>
+            ) : null}
+
+            <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5">
+              <h3 className="text-lg font-semibold text-brand-primary">Hero section</h3>
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="font-medium text-slate-700">Eyebrow</span>
+                  <input
+                    type="text"
+                    value={aboutDraft?.hero?.eyebrow ?? ''}
+                    onChange={(event) => handleHeroFieldChange('eyebrow', event.target.value)}
+                    className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                  <span className="font-medium text-slate-700">Subtitle</span>
+                  <input
+                    type="text"
+                    value={aboutDraft?.hero?.subtitle ?? ''}
+                    onChange={(event) => handleHeroFieldChange('subtitle', event.target.value)}
+                    className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                  />
+                </label>
+              </div>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-slate-700">Title</span>
+                <input
+                  type="text"
+                  value={aboutDraft?.hero?.title ?? ''}
+                  onChange={(event) => handleHeroFieldChange('title', event.target.value)}
+                  className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-slate-700">Description</span>
+                <textarea
+                  value={aboutDraft?.hero?.description ?? ''}
+                  onChange={(event) => handleHeroFieldChange('description', event.target.value)}
+                  rows={3}
+                  className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                />
+              </label>
+
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-sm font-semibold text-slate-700">Hero statistics</h4>
+                  <button
+                    type="button"
+                    onClick={handleAddHeroStat}
+                    className="text-sm font-medium text-brand-primary hover:text-brand-dark"
+                  >
+                    + Add stat
+                  </button>
+                </div>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {(aboutDraft?.hero?.stats ?? []).map((stat, index) => (
+                    <div key={`stat-${index}`} className="flex flex-col gap-2 rounded-xl border border-slate-200 p-3">
+                      <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                        Label
+                        <input
+                          type="text"
+                          value={stat?.label ?? ''}
+                          onChange={(event) => handleHeroStatChange(index, 'label', event.target.value)}
+                          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                        />
+                      </label>
+                      <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                        Value
+                        <input
+                          type="text"
+                          value={stat?.value ?? ''}
+                          onChange={(event) => handleHeroStatChange(index, 'value', event.target.value)}
+                          className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                        />
+                      </label>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveHeroStat(index)}
+                        className="self-start text-xs font-medium text-rose-500 hover:text-rose-600"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="space-y-4">
+              <div className="flex items-center justify-between">
+                <h3 className="text-lg font-semibold text-brand-primary">Supporting sections</h3>
+                <button
+                  type="button"
+                  onClick={handleAddSection}
+                  className="text-sm font-medium text-brand-primary hover:text-brand-dark"
+                >
+                  + Add section
+                </button>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                {(aboutDraft?.sections ?? []).map((section, index) => (
+                  <article key={`section-${index}`} className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4">
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Title
+                      <input
+                        type="text"
+                        value={section?.title ?? ''}
+                        onChange={(event) => handleSectionFieldChange(index, 'title', event.target.value)}
+                        className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Body
+                      <textarea
+                        value={section?.body ?? ''}
+                        onChange={(event) => handleSectionFieldChange(index, 'body', event.target.value)}
+                        rows={3}
+                        className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                      />
+                    </label>
+                    <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                      Bullet points (one per line)
+                      <textarea
+                        value={(section?.bullets ?? []).join('\n')}
+                        onChange={(event) => handleSectionBulletsChange(index, event.target.value)}
+                        rows={3}
+                        className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveSection(index)}
+                      className="self-start text-xs font-medium text-rose-500 hover:text-rose-600"
+                    >
+                      Remove section
+                    </button>
+                  </article>
+                ))}
+              </div>
+            </section>
+
+            <section className="grid gap-4 rounded-2xl border border-slate-200 bg-white p-5">
+              <h3 className="text-lg font-semibold text-brand-primary">Call-to-action</h3>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-slate-700">Title</span>
+                <input
+                  type="text"
+                  value={aboutDraft?.callout?.title ?? ''}
+                  onChange={(event) => handleCalloutChange('title', event.target.value)}
+                  className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm">
+                <span className="font-medium text-slate-700">Description</span>
+                <textarea
+                  value={aboutDraft?.callout?.description ?? ''}
+                  onChange={(event) => handleCalloutChange('description', event.target.value)}
+                  rows={3}
+                  className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                />
+              </label>
+            </section>
+          </form>
+        )
+      ) : null}
+
+      {activeTab === 'packages' ? (
+        packagesStatus === 'loading' ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-slate-600">Loading service packages...</div>
+        ) : packagesError ? (
+          <div className="flex min-h-[12rem] items-center justify-center text-red-600">{packagesError}</div>
+        ) : (
+          <section className="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold text-brand-primary">Diagnostic packages</h2>
+                <p className="text-sm text-slate-600">Update pricing, descriptions, and the tests included in each promotional package.</p>
+              </div>
+              <button
+                type="button"
+                onClick={handleAddPackage}
+                className="inline-flex items-center justify-center rounded-full border border-brand-primary px-5 py-2 text-sm font-semibold text-brand-primary transition hover:bg-brand-primary hover:text-white"
+              >
+                + Add new package
+              </button>
+            </header>
+
+            {packageFeedback ? (
+              <div
+                className={`rounded-2xl border px-4 py-3 text-sm ${
+                  packageFeedback.type === 'success'
+                    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                    : 'border-rose-200 bg-rose-50 text-rose-700'
+                }`}
+              >
+                {packageFeedback.message}
+              </div>
+            ) : null}
+
+            <div className="space-y-6">
+              {sortedPackageDrafts.map((pkg, index) => {
+                const key = pkg.id ?? `draft-${index}`;
+                const items = Array.isArray(pkg.items) ? pkg.items : [];
+                const total = items.reduce((sum, item) => sum + (Number.parseFloat(item.price) || 0), 0);
+                const discounted = Number.parseFloat(pkg.discountedPrice) || 0;
+                const saving = Math.max(0, total - discounted);
+
+                return (
+                  <article key={key} className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5">
+                    <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                      <div className="space-y-3">
+                        <label className="flex flex-col gap-1 text-sm">
+                          <span className="font-medium text-slate-700">Package name</span>
+                          <input
+                            type="text"
+                            value={pkg.name}
+                            onChange={(event) => handlePackageFieldChange(index, 'name', event.target.value)}
+                            className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                          />
+                        </label>
+                        <label className="flex flex-col gap-1 text-sm">
+                          <span className="font-medium text-slate-700">Subtitle</span>
+                          <input
+                            type="text"
+                            value={pkg.subtitle}
+                            onChange={(event) => handlePackageFieldChange(index, 'subtitle', event.target.value)}
+                            className="rounded-xl border border-slate-200 px-4 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                          />
+                        </label>
+                      </div>
+
+                      <div className="grid gap-3 sm:grid-cols-3">
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                          Sort order
+                          <input
+                            type="number"
+                            value={pkg.sortOrder}
+                            onChange={(event) => handlePackageFieldChange(index, 'sortOrder', event.target.value)}
+                            className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                          />
+                        </label>
+                        <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                          Discounted price (BDT)
+                          <input
+                            type="number"
+                            min="0"
+                            step="0.01"
+                            value={pkg.discountedPrice}
+                            onChange={(event) => handlePackageFieldChange(index, 'discountedPrice', event.target.value)}
+                            className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                          />
+                        </label>
+                        <div className="flex flex-col justify-center rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+                          <span>Total tests value: <strong className="text-slate-900">BDT {total.toLocaleString('en-US')}</strong></span>
+                          <span>Savings: <strong className="text-emerald-600">BDT {saving.toLocaleString('en-US')}</strong></span>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <h4 className="text-sm font-semibold text-slate-700">Package items</h4>
+                        <button
+                          type="button"
+                          onClick={() => handleAddPackageItem(index)}
+                          className="text-sm font-medium text-brand-primary hover:text-brand-dark"
+                        >
+                          + Add item
+                        </button>
+                      </div>
+                      <div className="grid gap-3 md:grid-cols-2">
+                        {items.map((item, itemIndex) => (
+                          <div key={`${key}-item-${itemIndex}`} className="flex flex-col gap-2 rounded-xl border border-slate-200 p-3">
+                            <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                              Item name
+                              <input
+                                type="text"
+                                value={item.name}
+                                onChange={(event) => handlePackageItemChange(index, itemIndex, 'name', event.target.value)}
+                                className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                              />
+                            </label>
+                            <label className="flex flex-col gap-1 text-xs font-medium text-slate-600">
+                              Price (BDT)
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.01"
+                                value={item.price}
+                                onChange={(event) => handlePackageItemChange(index, itemIndex, 'price', event.target.value)}
+                                className="rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-700 focus:border-brand-primary focus:outline-none"
+                              />
+                            </label>
+                            <button
+                              type="button"
+                              onClick={() => handleRemovePackageItem(index, itemIndex)}
+                              className="self-start text-xs font-medium text-rose-500 hover:text-rose-600"
+                            >
+                              Remove item
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="flex gap-3">
+                        <button
+                          type="button"
+                          onClick={() => handleSavePackage(pkg, index)}
+                          disabled={packageSavingKey === (pkg.id ?? `new-${index}`)}
+                          className="inline-flex items-center justify-center rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-dark disabled:cursor-not-allowed disabled:bg-slate-400"
+                        >
+                          {packageSavingKey === (pkg.id ?? `new-${index}`) ? 'Saving...' : 'Save package'}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleDeletePackage(pkg, index)}
+                          disabled={packageDeletingKey === pkg.id}
+                          className="inline-flex items-center justify-center rounded-full border border-rose-200 px-4 py-2 text-sm font-semibold text-rose-500 transition hover:bg-rose-50 disabled:cursor-not-allowed disabled:border-slate-200 disabled:text-slate-400"
+                        >
+                          {packageDeletingKey === pkg.id ? 'Removing...' : 'Delete'}
+                        </button>
+                      </div>
+                      <span className="text-xs text-slate-500">Original value: BDT {total.toLocaleString('en-US')}</span>
+                    </div>
+                  </article>
+                );
+              })}
+
+              {sortedPackageDrafts.length === 0 ? (
+                <div className="rounded-2xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+                  No service packages found. Add your first package to highlight diagnostic bundles on the public site.
+                </div>
+              ) : null}
+            </div>
+          </section>
+        )
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/pages/ServicesPage.jsx
+++ b/frontend/src/pages/ServicesPage.jsx
@@ -1,53 +1,164 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-const services = [
-  {
-    title: 'Specialist Consultations',
-    description: 'Personalized visits with top specialists in cardiology, neurology, oncology, and more.',
-  },
-  {
-    title: 'Diagnostic & Imaging',
-    description: 'Same-day laboratory work, imaging appointments, and follow-up coordination.',
-  },
-  {
-    title: 'Preventive Care Plans',
-    description: 'Long-term wellness plans designed by our care team to keep you thriving every day.',
-  },
-];
+const apiBaseUrl = process.env.REACT_APP_API_URL;
+
+const formatCurrency = (value) => {
+  const amount = Number.parseFloat(value ?? 0) || 0;
+  return `BDT ${amount.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+};
 
 function ServicesPage() {
+  const [packages, setPackages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const fetchPackages = async () => {
+      setLoading(true);
+      setError('');
+
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/content/service-packages`);
+        if (!response.ok) {
+          throw new Error('Unable to load service packages.');
+        }
+
+        const data = await response.json();
+        setPackages(Array.isArray(data) ? data : []);
+      } catch (err) {
+        setError(err.message || 'An unexpected error occurred while loading the packages.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPackages();
+  }, []);
+
+  const sortedPackages = useMemo(() => {
+    return [...packages].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0));
+  }, [packages]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-slate-600">
+        Gathering wellness packages...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex min-h-[calc(100vh-7rem)] items-center justify-center text-red-600">
+        {error}
+      </div>
+    );
+  }
+
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-4 pb-16 pt-4 sm:px-6 lg:px-8">
-      <section className="rounded-3xl border border-white/60 bg-white/70 p-10 shadow-glass backdrop-blur-xl">
-        <div className="max-w-2xl space-y-4">
-          <span className="inline-flex items-center rounded-full bg-brand-secondary px-4 py-1 text-xs font-semibold uppercase tracking-wide text-brand-dark">
-            Our Services
-          </span>
-          <h1 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Comprehensive care tailored to you</h1>
-          <p className="text-base text-slate-600 sm:text-lg">
-            Discover the programs, clinics, and support teams that power our medical network. We combine compassionate specialists with seamless technology to support you at every step.
-          </p>
-        </div>
-
-        <div className="mt-10 grid gap-6 md:grid-cols-3">
-          {services.map((service) => (
-            <div key={service.title} className="flex flex-col gap-3 rounded-2xl border border-emerald-100 bg-white/80 p-6 shadow-soft">
-              <h3 className="text-lg font-semibold text-brand-dark">{service.title}</h3>
-              <p className="text-sm text-slate-600">{service.description}</p>
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pb-16 pt-4 sm:px-6 lg:px-8">
+      <section className="rounded-3xl border border-white/40 bg-white/80 p-10 shadow-glass backdrop-blur-xl">
+        <div className="grid gap-6 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="space-y-5">
+            <span className="inline-flex items-center rounded-full bg-brand-secondary px-4 py-1 text-xs font-semibold uppercase tracking-wide text-brand-dark">
+              Destination Health Packages
+            </span>
+            <h1 className="text-3xl font-semibold text-slate-900 sm:text-4xl lg:text-5xl">Preventive health, designed for every stage of life</h1>
+            <p className="text-base text-slate-600 sm:text-lg">
+              From essential checkups to advanced diagnostics, each package blends laboratory tests, imaging, and consultations
+              so you can take proactive steps toward long-term wellness.
+            </p>
+            <div className="grid gap-4 rounded-2xl border border-brand-primary/20 bg-brand-primary/10 p-5 text-sm text-brand-dark sm:grid-cols-2">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-brand-dark/70">Same-day reporting</p>
+                <p className="mt-1 text-lg font-semibold text-brand-dark">Results delivered digitally for quick follow-up</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-brand-dark/70">Personal guidance</p>
+                <p className="mt-1 text-lg font-semibold text-brand-dark">Care coordinators to review every outcome</p>
+              </div>
             </div>
-          ))}
-        </div>
+          </div>
 
-        <div className="mt-10 inline-flex items-center gap-3 rounded-full border border-brand-primary/30 bg-brand-primary/10 px-6 py-3 text-sm text-brand-dark">
-          Looking for a specific program?
-          <Link
-            to="/book-appointment"
-            className="rounded-full bg-brand-primary px-4 py-2 text-white shadow-soft transition hover:bg-brand-dark"
-          >
-            Book a visit
-          </Link>
+          <div className="flex flex-col justify-between rounded-3xl border border-brand-primary/20 bg-brand-primary/5 p-8">
+            <div className="space-y-3">
+              <h2 className="text-xl font-semibold text-brand-primary">Not sure where to begin?</h2>
+              <p className="text-sm text-slate-600">
+                Share your health goals with our coordinators and they will recommend the right screening path or specialist
+                consultation for you or your loved ones.
+              </p>
+            </div>
+            <Link
+              to="/book-appointment"
+              className="mt-6 inline-flex items-center justify-center rounded-full bg-brand-primary px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-brand-dark"
+            >
+              Book a consultation
+            </Link>
+          </div>
         </div>
+      </section>
+
+      <section className="space-y-8">
+        {sortedPackages.map((pkg) => {
+          const packageItems = Array.isArray(pkg.items) ? pkg.items : [];
+          const totalPrice = packageItems.reduce((sum, item) => sum + (Number.parseFloat(item.price ?? 0) || 0), 0);
+          const discountedPrice = Number.parseFloat(pkg.discountedPrice ?? pkg.totalPrice ?? 0) || 0;
+          const savings = Math.max(0, totalPrice - discountedPrice);
+
+          return (
+            <article
+              key={pkg.id ?? pkg.name}
+              className="rounded-3xl border border-slate-200 bg-white/95 p-8 shadow-card backdrop-blur"
+            >
+              <header className="flex flex-col gap-4 border-b border-slate-200 pb-6 sm:flex-row sm:items-end sm:justify-between">
+                <div className="space-y-2">
+                  <h2 className="text-2xl font-semibold text-brand-primary">{pkg.name}</h2>
+                  {pkg.subtitle ? <p className="text-sm text-slate-600 sm:text-base">{pkg.subtitle}</p> : null}
+                </div>
+                <div className="flex flex-wrap items-end gap-6 text-slate-700">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-slate-500">Total value</p>
+                    <p className="text-lg font-semibold text-slate-900">{formatCurrency(totalPrice)}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-brand-primary">Discounted package</p>
+                    <p className="text-2xl font-semibold text-brand-primary">{formatCurrency(discountedPrice)}</p>
+                  </div>
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-emerald-600">You save</p>
+                    <p className="text-lg font-semibold text-emerald-600">{formatCurrency(savings)}</p>
+                  </div>
+                </div>
+              </header>
+
+              <div className="mt-6 grid gap-4 md:grid-cols-2">
+                {packageItems.map((item) => (
+                  <div
+                    key={item.id ?? `${pkg.name}-${item.name}`}
+                    className="flex items-center justify-between rounded-2xl border border-slate-100 bg-slate-50/70 px-4 py-3 text-sm text-slate-700 shadow-sm"
+                  >
+                    <span className="pr-4 text-slate-800">{item.name}</span>
+                    <span className="font-semibold text-brand-primary">{formatCurrency(item.price)}</span>
+                  </div>
+                ))}
+              </div>
+
+              <footer className="mt-8 flex flex-wrap items-center justify-between gap-4 text-sm text-slate-600">
+                <p className="flex items-center gap-2">
+                  <span className="inline-flex h-2 w-2 rounded-full bg-brand-primary" aria-hidden="true" />
+                  Includes all consumables, reporting, and physician review.
+                </p>
+                <Link
+                  to="/book-appointment"
+                  className="inline-flex items-center justify-center rounded-full border border-brand-primary px-5 py-2 font-medium text-brand-primary transition hover:bg-brand-primary hover:text-white"
+                >
+                  Schedule this package
+                </Link>
+              </footer>
+            </article>
+          );
+        })}
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- add site content and service package tables with seed data and API support
- expose public content routes and admin CRUD endpoints for marketing content updates
- redesign the about and services pages to consume API data and extend the admin dashboard with editing tools

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e14aedb5d08322af24a1e284ac89d4