### PR TITLE
Enable guest-friendly appointment booking

### DIFF
--- a/backend/src/controllers/appointmentController.js
+++ b/backend/src/controllers/appointmentController.js
@@ -1,11 +1,11 @@
+const jwt = require('jsonwebtoken');
+const config = require('../config/env');
 const { getAvailableTimes, bookAppointment } = require('../services/appointmentService');
+const { createPatient, savePatientDocument } = require('../services/patientService');
+const { storeFile } = require('../services/storageService');
 
-// Lists available appointment slots for the authenticated patient.
-async function getAvailableTimesForPatient(req, res) {
-  if (req.user.role !== 'patient') {
-    return res.status(403).json({ error: 'Only patients can view available times.' });
-  }
-
+// Lists available appointment slots for the provided doctor identifier.
+async function getAvailableTimesHandler(req, res) {
   const doctorIdParam = req.query.doctorId;
   const doctorId = Number.parseInt(doctorIdParam, 10);
 
@@ -17,24 +17,140 @@ async function getAvailableTimesForPatient(req, res) {
   return res.json(availableTimes);
 }
 
-// Books an appointment for the authenticated patient using a transactional workflow.
-async function bookAppointmentForPatient(req, res) {
-  if (req.user.role !== 'patient') {
-    return res.status(403).json({ error: 'Only patients can book appointments.' });
+function validateGuestPayload(payload) {
+  const requiredFields = [
+    'fullName',
+    'birthdate',
+    'gender',
+    'phoneNumber',
+    'email',
+    'password',
+    'address',
+    'nidNumber',
+  ];
+
+  const missingField = requiredFields.find((field) => !payload[field]);
+  if (missingField) {
+    const error = new Error(`Field ${missingField} is required.`);
+    error.statusCode = 400;
+    throw error;
   }
 
-  const patientId = req.user.id;
-  const { availableTimeID } = req.body;
+  const bangladeshPhoneRegex = /^(\+?88)?01[3-9]\d{8}$/;
+  if (!bangladeshPhoneRegex.test(payload.phoneNumber)) {
+    const error = new Error('Phone number must be a valid Bangladeshi number.');
+    error.statusCode = 400;
+    throw error;
+  }
+}
+
+async function persistDocuments(patientId, appointmentId, files = []) {
+  if (!files.length) {
+    return [];
+  }
+
+  const stored = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for (const file of files) {
+    // eslint-disable-next-line no-await-in-loop
+    const url = await storeFile(file, 'patient-documents');
+    if (url) {
+      stored.push({ name: file.originalname, url });
+      // eslint-disable-next-line no-await-in-loop
+      await savePatientDocument(patientId, file.originalname, url, appointmentId);
+    }
+  }
+
+  return stored;
+}
+
+// Books an appointment, creating a patient account when the request is anonymous.
+async function bookAppointmentHandler(req, res) {
+  const { availableTimeID, notes = '' } = req.body;
   const slotId = Number.parseInt(availableTimeID, 10);
 
   if (Number.isNaN(slotId)) {
     return res.status(400).json({ error: 'availableTimeID is required.' });
   }
 
-  const appointment = await bookAppointment({ patientId, availableTimeId: slotId });
+  const files = req.files || [];
 
-  return res.json({
-    message: 'Appointment booked successfully',
+  if (req.user) {
+    if (req.user.role !== 'patient') {
+      return res.status(403).json({ error: 'Only patients can book appointments.' });
+    }
+
+    const appointment = await bookAppointment({
+      patientId: req.user.id,
+      availableTimeId: slotId,
+      notes,
+    });
+
+    await persistDocuments(req.user.id, appointment.appointmentId, files);
+
+    return res.json({
+      message: 'Appointment booked successfully',
+      appointment: {
+        AppointmentID: appointment.appointmentId,
+        DoctorID: appointment.doctorId,
+        ScheduleDate: appointment.scheduleDate,
+        StartTime: appointment.startTime,
+        EndTime: appointment.endTime,
+        Status: 'pending',
+        Notes: appointment.notes,
+      },
+    });
+  }
+
+  try {
+    validateGuestPayload(req.body);
+  } catch (error) {
+    return res
+      .status(error.statusCode || 400)
+      .json({ error: error.message || 'Invalid booking request.' });
+  }
+
+  const patient = await createPatient({
+    fullName: req.body.fullName,
+    birthDate: req.body.birthdate,
+    gender: req.body.gender,
+    phoneNumber: req.body.phoneNumber,
+    email: req.body.email,
+    password: req.body.password,
+    address: req.body.address,
+    nidNumber: req.body.nidNumber,
+    documents: [],
+  });
+
+  const appointment = await bookAppointment({
+    patientId: patient.id,
+    availableTimeId: slotId,
+    notes,
+  });
+
+  await persistDocuments(patient.id, appointment.appointmentId, files);
+
+  const tokenPayload = {
+    userId: patient.userId,
+    id: patient.id,
+    role: 'patient',
+    email: patient.email,
+    ...(patient.fullName ? { fullName: patient.fullName } : {}),
+  };
+
+  const token = jwt.sign(tokenPayload, config.jwt.secret, {
+    expiresIn: config.jwt.expiresIn,
+  });
+
+  return res.status(201).json({
+    message: 'Account created and appointment booked successfully',
+    token,
+    user: {
+      id: patient.id,
+      fullName: patient.fullName,
+      email: patient.email,
+      role: 'patient',
+    },
     appointment: {
       AppointmentID: appointment.appointmentId,
       DoctorID: appointment.doctorId,
@@ -42,11 +158,12 @@ async function bookAppointmentForPatient(req, res) {
       StartTime: appointment.startTime,
       EndTime: appointment.endTime,
       Status: 'pending',
+      Notes: appointment.notes,
     },
   });
 }
 
 module.exports = {
-  getAvailableTimesForPatient,
-  bookAppointmentForPatient,
+  getAvailableTimesHandler,
+  bookAppointmentHandler,
 };

--- a/backend/src/database/schema.js
+++ b/backend/src/database/schema.js
@@ -202,6 +202,8 @@ async function createPatientDocumentsTable() {
         ON DELETE CASCADE
     )`
   );
+
+  await addColumnIfMissing('patient_documents', 'AppointmentID', 'INT NULL');
 }
 
 async function createDoctorReportsTable() {

--- a/backend/src/middleware/authenticateOptional.js
+++ b/backend/src/middleware/authenticateOptional.js
@@ -1,0 +1,25 @@
+const jwt = require('jsonwebtoken');
+const config = require('../config/env');
+
+// Attempts to authenticate the incoming request but allows anonymous access.
+function authenticateOptional(req, _res, next) {
+  const authorizationHeader = req.headers.authorization;
+
+  if (!authorizationHeader?.startsWith('Bearer ')) {
+    req.user = null;
+    return next();
+  }
+
+  const token = authorizationHeader.slice(7);
+
+  try {
+    const payload = jwt.verify(token, config.jwt.secret);
+    req.user = payload;
+  } catch (error) {
+    req.user = null;
+  }
+
+  return next();
+}
+
+module.exports = authenticateOptional;

--- a/backend/src/routes/appointmentRoutes.js
+++ b/backend/src/routes/appointmentRoutes.js
@@ -1,26 +1,21 @@
 const { Router } = require('express');
 const asyncHandler = require('../utils/asyncHandler');
-const authenticateToken = require('../middleware/authenticate');
-const authorizeRoles = require('../middleware/authorizeRoles');
+const authenticateOptional = require('../middleware/authenticateOptional');
+const upload = require('../middleware/upload');
 const {
-  getAvailableTimesForPatient,
-  bookAppointmentForPatient,
+  getAvailableTimesHandler,
+  bookAppointmentHandler,
 } = require('../controllers/appointmentController');
 
 const router = Router();
 
 // Appointment scheduling endpoints.
-router.get(
-  '/available-times',
-  authenticateToken,
-  authorizeRoles('patient'),
-  asyncHandler(getAvailableTimesForPatient)
-);
+router.get('/available-times', authenticateOptional, asyncHandler(getAvailableTimesHandler));
 router.post(
   '/book',
-  authenticateToken,
-  authorizeRoles('patient'),
-  asyncHandler(bookAppointmentForPatient)
+  authenticateOptional,
+  upload.array('documents', 5),
+  asyncHandler(bookAppointmentHandler)
 );
 
 module.exports = router;

--- a/frontend/src/features/home/components/BookingCard.jsx
+++ b/frontend/src/features/home/components/BookingCard.jsx
@@ -1,105 +1,229 @@
-import React, { useState } from 'react';
-import { FaCalendarAlt, FaUserMd, FaClinicMedical, FaClock } from 'react-icons/fa';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+import { FaCalendarAlt, FaUserMd, FaClock } from 'react-icons/fa';
 import { useNavigate } from 'react-router-dom';
-
-const specialistOptions = [
-  { value: 'cardiology', label: 'Cardiology' },
-  { value: 'dermatology', label: 'Dermatology' },
-  { value: 'pediatrics', label: 'Pediatrics' },
-  { value: 'orthopedics', label: 'Orthopedics' },
-  { value: 'mental-health', label: 'Mental Health' },
-];
-
-const doctorOptions = [
-  { value: 'dr-jordan', label: 'Dr. Jordan Smith' },
-  { value: 'dr-owens', label: 'Dr. Natalie Owens' },
-  { value: 'dr-ramirez', label: 'Dr. Lucia Ramirez' },
-  { value: 'dr-wells', label: 'Dr. Amir Wells' },
-];
+import { AuthContext } from '../../auth/context/AuthContext';
 
 function BookingCard() {
   const navigate = useNavigate();
-  const [bookingForm, setBookingForm] = useState({
-    specialist: specialistOptions[0].value,
-    doctor: doctorOptions[0].value,
-    date: '',
-    time: '',
-  });
+  const { auth, login } = useContext(AuthContext);
+  const apiBaseUrl = (process.env.REACT_APP_API_URL || '').replace(/\/$/, '');
 
-  const handleChange = (event) => {
-    const { name, value } = event.target;
-    setBookingForm((prev) => ({ ...prev, [name]: value }));
+  const [doctors, setDoctors] = useState([]);
+  const [selectedDoctorId, setSelectedDoctorId] = useState('');
+  const [availableTimes, setAvailableTimes] = useState([]);
+  const [uniqueDates, setUniqueDates] = useState([]);
+  const [selectedDate, setSelectedDate] = useState('');
+  const [selectedSlotId, setSelectedSlotId] = useState('');
+  const [notes, setNotes] = useState('');
+  const [availabilityStatus, setAvailabilityStatus] = useState('idle');
+  const [submissionStatus, setSubmissionStatus] = useState('idle');
+  const [message, setMessage] = useState({ type: '', text: '' });
+
+  useEffect(() => {
+    const loadDoctors = async () => {
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/doctors`);
+        if (!response.ok) {
+          throw new Error('Unable to load doctors right now.');
+        }
+        const data = await response.json();
+        setDoctors(data);
+        if (data.length > 0) {
+          setSelectedDoctorId(String(data[0].DoctorID));
+        }
+      } catch (error) {
+        setMessage({ type: 'error', text: error.message || 'Unable to load doctors.' });
+      }
+    };
+
+    loadDoctors();
+  }, [apiBaseUrl]);
+
+  useEffect(() => {
+    if (!selectedDoctorId) {
+      setAvailableTimes([]);
+      setUniqueDates([]);
+      setSelectedDate('');
+      setSelectedSlotId('');
+      return;
+    }
+
+    const loadAvailability = async () => {
+      setAvailabilityStatus('loading');
+      setSelectedDate('');
+      setSelectedSlotId('');
+
+      try {
+        const response = await fetch(
+          `${apiBaseUrl}/api/appointments/available-times?doctorId=${selectedDoctorId}`
+        );
+        if (!response.ok) {
+          throw new Error('Unable to load availability.');
+        }
+        const data = await response.json();
+        setAvailableTimes(data);
+        const dates = [...new Set(data.map((slot) => slot.ScheduleDate))].sort();
+        setUniqueDates(dates);
+        setAvailabilityStatus('succeeded');
+      } catch (error) {
+        setAvailabilityStatus('failed');
+        setAvailableTimes([]);
+        setUniqueDates([]);
+        setMessage({ type: 'error', text: error.message || 'Failed to load availability.' });
+      }
+    };
+
+    loadAvailability();
+  }, [apiBaseUrl, selectedDoctorId]);
+
+  const selectedDoctor = useMemo(
+    () => doctors.find((doctor) => String(doctor.DoctorID) === String(selectedDoctorId)) || null,
+    [doctors, selectedDoctorId]
+  );
+
+  const slotsForSelectedDate = useMemo(
+    () => availableTimes.filter((slot) => slot.ScheduleDate === selectedDate),
+    [availableTimes, selectedDate]
+  );
+
+  const messageStyles = {
+    success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    error: 'border-rose-200 bg-rose-50 text-rose-700',
+    info: 'border-sky-200 bg-sky-50 text-sky-700',
   };
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
-    navigate('/book-appointment', { state: bookingForm });
+
+    if (!selectedSlotId) {
+      setMessage({ type: 'error', text: 'Select a date and time to continue.' });
+      return;
+    }
+
+    if (!auth.token) {
+      navigate('/book-appointment', {
+        state: {
+          doctorId: selectedDoctorId,
+          date: selectedDate,
+          slotId: selectedSlotId,
+          notes,
+        },
+      });
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('availableTimeID', selectedSlotId);
+    if (notes.trim()) {
+      formData.append('notes', notes.trim());
+    }
+
+    setSubmissionStatus('submitting');
+    setMessage({ type: '', text: '' });
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/appointments/book`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${auth.token}`,
+        },
+        body: formData,
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || data.message || 'Unable to reserve the appointment.');
+      }
+
+      if (data.token && data.user) {
+        login(data.token, data.user);
+      }
+
+      setSubmissionStatus('succeeded');
+      setMessage({ type: 'success', text: 'Appointment reserved! Redirecting to your profile…' });
+      setTimeout(() => navigate('/myprofile'), 2000);
+    } catch (error) {
+      setSubmissionStatus('failed');
+      setMessage({ type: 'error', text: error.message || 'Unable to reserve the appointment.' });
+    }
   };
 
   return (
     <div className="w-full rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-card shadow-blue-100/70 backdrop-blur">
       <div className="mb-6 flex items-center gap-3">
         <span className="flex h-12 w-12 items-center justify-center rounded-2xl bg-blue-100 text-2xl text-brand-primary">
-          <FaClinicMedical />
+          <FaUserMd />
         </span>
         <div>
-          <h2 className="text-lg font-semibold text-slate-900">Find your next appointment</h2>
-          <p className="text-sm text-slate-500">Select a specialist, doctor, and time that suits you.</p>
+          <h2 className="text-lg font-semibold text-slate-900">Quick appointment booking</h2>
+          <p className="text-sm text-slate-500">Reserve the next available slot with a preferred doctor.</p>
         </div>
       </div>
 
+      {message.text ? (
+        <div
+          className={`mb-4 rounded-xl border px-3 py-2 text-xs font-semibold ${
+            messageStyles[message.type] || 'border-slate-200 bg-slate-100 text-slate-700'
+          }`}
+        >
+          {message.text}
+        </div>
+      ) : null}
+
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
         <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-          Specialist
+          Doctor
           <span className="relative">
             <FaUserMd className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
             <select
-              name="specialist"
-              value={bookingForm.specialist}
-              onChange={handleChange}
+              name="doctor"
+              value={selectedDoctorId}
+              onChange={(event) => setSelectedDoctorId(event.target.value)}
               className="w-full appearance-none rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
             >
-              {specialistOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
+              {doctors.map((doctor) => (
+                <option key={doctor.DoctorID} value={doctor.DoctorID}>
+                  {doctor.FullName}
+                  {doctor.Specialization ? ` — ${doctor.Specialization}` : ''}
                 </option>
               ))}
             </select>
           </span>
         </label>
 
-        <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
-          Doctor
-          <span className="relative">
-            <FaClinicMedical className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-            <select
-              name="doctor"
-              value={bookingForm.doctor}
-              onChange={handleChange}
-              className="w-full appearance-none rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
-            >
-              {doctorOptions.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </span>
-        </label>
+        {selectedDoctor ? (
+          <p className="rounded-2xl bg-slate-50 px-4 py-3 text-xs text-slate-600">
+            {selectedDoctor.Specialization
+              ? `${selectedDoctor.FullName} • ${selectedDoctor.Specialization}`
+              : `${selectedDoctor.FullName} • General consultation`}
+          </p>
+        ) : null}
 
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
             Date
             <span className="relative">
               <FaCalendarAlt className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-              <input
-                type="date"
+              <select
                 name="date"
-                value={bookingForm.date}
-                onChange={handleChange}
-                className="w-full rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
-                required
-              />
+                value={selectedDate}
+                onChange={(event) => {
+                  setSelectedDate(event.target.value);
+                  setSelectedSlotId('');
+                }}
+                className="w-full rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30 disabled:cursor-not-allowed"
+                disabled={!uniqueDates.length}
+              >
+                <option value="">-- Select --</option>
+                {uniqueDates.map((date) => (
+                  <option key={date} value={date}>
+                    {new Date(date).toLocaleDateString('en-US', {
+                      weekday: 'short',
+                      month: 'short',
+                      day: 'numeric',
+                    })}
+                  </option>
+                ))}
+              </select>
             </span>
           </label>
 
@@ -107,23 +231,55 @@ function BookingCard() {
             Time
             <span className="relative">
               <FaClock className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-slate-400" />
-              <input
-                type="time"
+              <select
                 name="time"
-                value={bookingForm.time}
-                onChange={handleChange}
-                className="w-full rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
-                required
-              />
+                value={selectedSlotId}
+                onChange={(event) => setSelectedSlotId(event.target.value)}
+                className="w-full rounded-2xl border border-slate-200 bg-white px-10 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30 disabled:cursor-not-allowed"
+                disabled={!selectedDate || !slotsForSelectedDate.length}
+              >
+                <option value="">-- Select --</option>
+                {slotsForSelectedDate.map((slot) => (
+                  <option key={slot.AvailableTimeID} value={slot.AvailableTimeID}>
+                    {slot.StartTime} - {slot.EndTime}
+                  </option>
+                ))}
+              </select>
             </span>
           </label>
         </div>
 
+        {availabilityStatus === 'loading' ? (
+          <p className="text-xs text-slate-500">Checking the latest availability…</p>
+        ) : null}
+        {!uniqueDates.length && availabilityStatus === 'succeeded' ? (
+          <p className="rounded-2xl bg-amber-50 px-4 py-3 text-xs text-amber-700">
+            No upcoming slots right now. Try another doctor or check back soon.
+          </p>
+        ) : null}
+
+        <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+          Quick note for the doctor (optional)
+          <textarea
+            name="notes"
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            rows={3}
+            className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            placeholder="Describe your primary concern."
+          />
+        </label>
+
         <button
           type="submit"
-          className="mt-2 inline-flex items-center justify-center rounded-2xl bg-brand-primary px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-primary/30 transition hover:-translate-y-0.5 hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+          className="mt-2 inline-flex items-center justify-center rounded-2xl bg-brand-primary px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-primary/30 transition hover:-translate-y-0.5 hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:bg-slate-300"
+          disabled={
+            submissionStatus === 'submitting' ||
+            availabilityStatus === 'loading' ||
+            !selectedSlotId
+          }
         >
-          Check availability
+          {submissionStatus === 'submitting' ? 'Reserving…' : auth.token ? 'Reserve now' : 'Continue to book'}
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- allow appointment availability lookup without authentication and add a guest booking workflow that creates patient accounts, attaches notes, and uploads documents
- extend patient document storage to link optional appointments and add optional authentication middleware for booking routes
- redesign the booking and quick-book experiences with registration prompts, notes, and medical document uploads tied into the unified API

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_b_68e1d1b7fc9883229ca40fa6a3897744