### PR TITLE
Enhance doctor scheduling and management dashboards

### DIFF
--- a/backend/src/routes/doctorRoutes.js
+++ b/backend/src/routes/doctorRoutes.js
@@ -14,6 +14,8 @@ const {
   updateDoctorProfileHandler,
   changeDoctorPassword,
   getDoctorProfile,
+  getDoctorAvailabilityForManagement,
+  updateDoctorAvailabilityStatus,
 } = require('../controllers/doctorController');
 
 const router = Router();
@@ -37,6 +39,12 @@ router.get(
   asyncHandler(getDoctorAppointments)
 );
 router.get(
+  '/:id/availability/manage',
+  authenticateToken,
+  authorizeRoles('doctor'),
+  asyncHandler(getDoctorAvailabilityForManagement)
+);
+router.get(
   '/:id/profile',
   authenticateToken,
   authorizeRoles('doctor', 'admin'),
@@ -47,6 +55,12 @@ router.post(
   authenticateToken,
   authorizeRoles('doctor'),
   asyncHandler(addAvailability)
+);
+router.patch(
+  '/:doctorId/availability/:slotId',
+  authenticateToken,
+  authorizeRoles('doctor'),
+  asyncHandler(updateDoctorAvailabilityStatus)
 );
 router.patch(
   '/appointments/:appointmentId/status',

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -32,6 +32,8 @@ function App() {
   };
 
   const defaultRedirect = getDefaultRoute(auth.user?.role);
+  const isManagementUser = auth.token && ['doctor', 'admin'].includes(auth.user?.role);
+  const guardPublicPage = (page) => (isManagementUser ? <Navigate to={defaultRedirect} replace /> : page);
 
   return (
     <Router>
@@ -40,12 +42,12 @@ function App() {
           <Header />
           <main className="flex-1 px-4 pb-12 pt-28 sm:px-8">
             <Routes>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/register" element={<RegisterPage />} />
-              <Route path="/about-us" element={<AboutUs />} />
-              <Route path="/services" element={<ServicesPage />} />
-              <Route path="/reports" element={<ReportsPage />} />
-              <Route path="/apply-as-doctor" element={<DoctorApplicationPage />} />
+              <Route path="/" element={guardPublicPage(<HomePage />)} />
+              <Route path="/register" element={guardPublicPage(<RegisterPage />)} />
+              <Route path="/about-us" element={guardPublicPage(<AboutUs />)} />
+              <Route path="/services" element={guardPublicPage(<ServicesPage />)} />
+              <Route path="/reports" element={guardPublicPage(<ReportsPage />)} />
+              <Route path="/apply-as-doctor" element={guardPublicPage(<DoctorApplicationPage />)} />
               <Route
                 path="/signin"
                 element={!auth.token ? <SignInLandingPage /> : <Navigate to={defaultRedirect} />}

--- a/frontend/src/shared/components/Header.jsx
+++ b/frontend/src/shared/components/Header.jsx
@@ -48,17 +48,9 @@ function Header() {
           { label: 'About Us', to: '/about-us' },
         ];
       case 'doctor':
-        return [
-          { label: 'Home', to: '/' },
-          { label: 'Services', to: '/services' },
-          { label: 'About Us', to: '/about-us' },
-        ];
+        return [{ label: 'Dashboard', to: dashboardLink.path }];
       case 'admin':
-        return [
-          { label: 'Home', to: '/' },
-          { label: 'Services', to: '/services' },
-          { label: 'About Us', to: '/about-us' },
-        ];
+        return [{ label: 'Dashboard', to: dashboardLink.path }];
       default:
         return [
           { label: 'Home', to: '/' },


### PR DESCRIPTION
## Summary
- add backend endpoints so doctors can retrieve and update their upcoming availability
- redirect doctors and administrators straight to their dashboards and simplify their navigation links
- rebuild the doctor portal availability planner with weekday/custom date selection, time presets, and slot toggles

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_b_68e1df2c90148322a272aedfb7dd18fd