### PR TITLE
Add Docker compose setup for hospital management stack

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Node.js runtime as the base image
+FROM node:20-alpine AS base
+
+WORKDIR /app
+
+# Install production dependencies based on the lockfile for reproducible builds
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+# Copy the application source
+COPY src ./src
+COPY populateAvailableTime.js ./
+COPY createtable.sql ./
+
+ENV NODE_ENV=production
+
+EXPOSE 5001
+
+# Start the API server
+CMD ["node", "src/server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,72 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:8.4
+    command: ["--default-authentication-plugin=mysql_native_password"]
+    environment:
+      MYSQL_ROOT_PASSWORD: example-password
+      MYSQL_DATABASE: clinic
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  minio:
+    image: minio/minio:RELEASE.2024-06-13T22-53-53Z
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin123
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+
+  backend:
+    build:
+      context: ./backend
+    environment:
+      PORT: 5001
+      NODE_ENV: production
+      JWT_SECRET: supersecretjwt
+      JWT_EXPIRES_IN: 7d
+      DB_HOST: db
+      DB_USER: root
+      DB_PASSWORD: example-password
+      DB_NAME: clinic
+      DB_CONNECTION_LIMIT: 10
+      MINIO_ENDPOINT: minio
+      MINIO_PORT: 9000
+      MINIO_ACCESS_KEY: minioadmin
+      MINIO_SECRET_KEY: minioadmin123
+      MINIO_BUCKET: hospital-data
+      MINIO_USE_SSL: "false"
+      MINIO_PUBLIC_URL: 'http://localhost:9000'
+    depends_on:
+      db:
+        condition: service_healthy
+      minio:
+        condition: service_started
+    ports:
+      - "5001:5001"
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        REACT_APP_API_URL: http://localhost:5001
+    depends_on:
+      - backend
+    ports:
+      - "3000:80"
+
+volumes:
+  mysql_data:
+  minio_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.env
+build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# Build stage: compile the React application
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+# Allow the API URL to be injected at build time
+ARG REACT_APP_API_URL
+ENV REACT_APP_API_URL=${REACT_APP_API_URL}
+
+RUN npm run build
+
+# Production stage: serve the static files with Nginx
+FROM nginx:1.27-alpine AS production
+
+COPY --from=build /app/build /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add a production-ready Dockerfile for the backend service
- add a multi-stage Dockerfile for the React frontend and ignore local build artifacts
- define a docker-compose stack with MySQL and MinIO dependencies for local orchestration

## Testing
- Not run (Docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68e1ed5f963483228f648dad032fd2af