### PR TITLE
Add editable homepage hero and doctor directory management

### DIFF
--- a/backend/src/controllers/adminContentController.js
+++ b/backend/src/controllers/adminContentController.js
@@ -3,6 +3,8 @@ const {
   updateAboutContent,
   getSiteSettings,
   updateSiteSettings,
+  getHomeHeroContent,
+  updateHomeHeroContent,
   getServicePackages,
   createServicePackage,
   updateServicePackage,
@@ -26,6 +28,16 @@ async function fetchSiteSettings(_req, res) {
 
 async function saveSiteSettings(req, res) {
   const updated = await updateSiteSettings(req.body);
+  res.json(updated);
+}
+
+async function fetchHomeHero(_req, res) {
+  const hero = await getHomeHeroContent();
+  res.json(hero);
+}
+
+async function saveHomeHero(req, res) {
+  const updated = await updateHomeHeroContent(req.body);
   res.json(updated);
 }
 
@@ -70,6 +82,8 @@ module.exports = {
   saveAboutContent,
   fetchSiteSettings,
   saveSiteSettings,
+  fetchHomeHero,
+  saveHomeHero,
   fetchServicePackages,
   createPackage,
   updatePackage,

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,4 +1,9 @@
-const { getOverviewMetrics } = require('../services/adminService');
+const {
+  getOverviewMetrics,
+  searchDoctorsDirectory,
+  getDoctorProfileForAdmin,
+  listDoctorAppointmentsForAdmin,
+} = require('../services/adminService');
 const {
   listDoctorApplications,
   reviewDoctorApplication,
@@ -38,8 +43,42 @@ async function reviewDoctorApplicationHandler(req, res) {
   return res.json({ message: 'Application reviewed successfully.', doctorId });
 }
 
+async function searchDoctorsDirectoryHandler(req, res) {
+  const { search = '' } = req.query;
+  const doctors = await searchDoctorsDirectory(search);
+  return res.json(doctors);
+}
+
+async function getDoctorDirectoryProfile(req, res) {
+  const doctorId = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(doctorId)) {
+    return res.status(400).json({ message: 'Invalid doctor identifier.' });
+  }
+
+  const doctor = await getDoctorProfileForAdmin(doctorId);
+  if (!doctor) {
+    return res.status(404).json({ message: 'Doctor not found.' });
+  }
+
+  return res.json(doctor);
+}
+
+async function getDoctorAppointmentsForAdminHandler(req, res) {
+  const doctorId = Number.parseInt(req.params.id, 10);
+  if (Number.isNaN(doctorId)) {
+    return res.status(400).json({ message: 'Invalid doctor identifier.' });
+  }
+
+  const scope = ['upcoming', 'history', 'all'].includes(req.query.scope) ? req.query.scope : 'all';
+  const appointments = await listDoctorAppointmentsForAdmin(doctorId, scope);
+  return res.json(appointments);
+}
+
 module.exports = {
   getOverview,
   getDoctorApplications,
   reviewDoctorApplicationHandler,
+  searchDoctorsDirectoryHandler,
+  getDoctorDirectoryProfile,
+  getDoctorAppointmentsForAdminHandler,
 };

--- a/backend/src/controllers/contentController.js
+++ b/backend/src/controllers/contentController.js
@@ -1,4 +1,9 @@
-const { getAboutContent, getServicePackages, getSiteSettings } = require('../services/contentService');
+const {
+  getAboutContent,
+  getServicePackages,
+  getSiteSettings,
+  getHomeHeroContent,
+} = require('../services/contentService');
 
 async function fetchAboutContent(_req, res) {
   const content = await getAboutContent();
@@ -15,8 +20,14 @@ async function fetchSiteSettings(_req, res) {
   res.json(settings);
 }
 
+async function fetchHomeHeroContent(_req, res) {
+  const hero = await getHomeHeroContent();
+  res.json(hero);
+}
+
 module.exports = {
   fetchAboutContent,
   fetchServicePackages,
   fetchSiteSettings,
+  fetchHomeHeroContent,
 };

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -6,12 +6,17 @@ const {
   getOverview,
   getDoctorApplications,
   reviewDoctorApplicationHandler,
+  searchDoctorsDirectoryHandler,
+  getDoctorDirectoryProfile,
+  getDoctorAppointmentsForAdminHandler,
 } = require('../controllers/adminController');
 const {
   fetchAboutContent,
   saveAboutContent,
   fetchSiteSettings,
   saveSiteSettings,
+  fetchHomeHero,
+  saveHomeHero,
   fetchServicePackages,
   createPackage,
   updatePackage,
@@ -32,6 +37,24 @@ router.post(
   authenticateToken,
   authorizeRoles('admin'),
   asyncHandler(reviewDoctorApplicationHandler)
+);
+router.get(
+  '/doctors',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(searchDoctorsDirectoryHandler)
+);
+router.get(
+  '/doctors/:id/profile',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(getDoctorDirectoryProfile)
+);
+router.get(
+  '/doctors/:id/appointments',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(getDoctorAppointmentsForAdminHandler)
 );
 router.get(
   '/content/about',
@@ -56,6 +79,18 @@ router.put(
   authenticateToken,
   authorizeRoles('admin'),
   asyncHandler(saveSiteSettings)
+);
+router.get(
+  '/content/home-hero',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(fetchHomeHero)
+);
+router.put(
+  '/content/home-hero',
+  authenticateToken,
+  authorizeRoles('admin'),
+  asyncHandler(saveHomeHero)
 );
 router.get(
   '/content/service-packages',

--- a/backend/src/routes/contentRoutes.js
+++ b/backend/src/routes/contentRoutes.js
@@ -1,11 +1,17 @@
 const { Router } = require('express');
 const asyncHandler = require('../utils/asyncHandler');
-const { fetchAboutContent, fetchServicePackages, fetchSiteSettings } = require('../controllers/contentController');
+const {
+  fetchAboutContent,
+  fetchServicePackages,
+  fetchSiteSettings,
+  fetchHomeHeroContent,
+} = require('../controllers/contentController');
 
 const router = Router();
 
 router.get('/about', asyncHandler(fetchAboutContent));
 router.get('/service-packages', asyncHandler(fetchServicePackages));
 router.get('/site-settings', asyncHandler(fetchSiteSettings));
+router.get('/home-hero', asyncHandler(fetchHomeHeroContent));
 
 module.exports = router;

--- a/backend/src/routes/doctorRoutes.js
+++ b/backend/src/routes/doctorRoutes.js
@@ -16,6 +16,7 @@ const {
   getDoctorProfile,
   getDoctorAvailabilityForManagement,
   updateDoctorAvailabilityStatus,
+  getPatientHistoryForDoctor,
 } = require('../controllers/doctorController');
 
 const router = Router();
@@ -49,6 +50,12 @@ router.get(
   authenticateToken,
   authorizeRoles('doctor', 'admin'),
   asyncHandler(getDoctorProfile)
+);
+router.get(
+  '/:doctorId/patients/:patientId/history',
+  authenticateToken,
+  authorizeRoles('doctor'),
+  asyncHandler(getPatientHistoryForDoctor)
 );
 router.post(
   '/:id/availability',

--- a/backend/src/services/adminService.js
+++ b/backend/src/services/adminService.js
@@ -1,17 +1,32 @@
 const { execute } = require('../database/query');
 
 async function getOverviewMetrics() {
-  const [patientCountRows, doctorCountRows, appointmentCountRows, upcomingAppointmentsRows] = await Promise.all([
-    execute('SELECT COUNT(*) AS totalPatients FROM patients'),
-    execute('SELECT COUNT(*) AS totalDoctors FROM doctors'),
-    execute('SELECT COUNT(*) AS totalAppointments FROM appointments'),
-    execute(
-      `SELECT COUNT(*) AS upcomingAppointments
+  const [patientCountRows, doctorCountRows, appointmentCountRows, upcomingAppointmentsRows, upcomingAppointmentsList] =
+    await Promise.all([
+      execute('SELECT COUNT(*) AS totalPatients FROM patients'),
+      execute('SELECT COUNT(*) AS totalDoctors FROM doctors'),
+      execute('SELECT COUNT(*) AS totalAppointments FROM appointments'),
+      execute(
+        `SELECT COUNT(*) AS upcomingAppointments
+           FROM appointments a
+           JOIN available_time at ON a.AvailableTimeID = at.AvailableTimeID
+           WHERE at.ScheduleDate >= CURDATE()`
+      ),
+      execute(
+        `SELECT
+            a.AppointmentID,
+            p.FullName AS PatientName,
+            d.FullName AS DoctorName,
+            CONCAT(at.ScheduleDate, 'T', at.StartTime) AS AppointmentDate
          FROM appointments a
          JOIN available_time at ON a.AvailableTimeID = at.AvailableTimeID
-         WHERE at.ScheduleDate >= CURDATE()`
-    ),
-  ]);
+         JOIN patients p ON a.PatientID = p.PatientID
+         JOIN doctors d ON a.DoctorID = d.DoctorID
+         WHERE at.ScheduleDate >= CURDATE()
+         ORDER BY at.ScheduleDate ASC, at.StartTime ASC
+         LIMIT 10`
+      ),
+    ]);
 
   const patientCountRow = patientCountRows[0] || {};
   const doctorCountRow = doctorCountRows[0] || {};
@@ -41,9 +56,96 @@ async function getOverviewMetrics() {
     },
     topDoctors,
     recentPatients,
+    upcomingAppointmentsList,
   };
+}
+
+async function searchDoctorsDirectory(searchTerm = '') {
+  const normalized = searchTerm.trim().toLowerCase();
+  const like = `%${normalized}%`;
+
+  const doctors = await execute(
+    `SELECT
+        d.DoctorID,
+        d.FullName,
+        d.Email,
+        d.PhoneNumber,
+        IFNULL(d.Specialization, '') AS Specialization,
+        d.MaxPatientNumber,
+        d.CurrentPatientNumber,
+        (SELECT COUNT(*) FROM appointments a WHERE a.DoctorID = d.DoctorID) AS TotalAppointments,
+        (SELECT COUNT(*)
+           FROM appointments a
+           JOIN available_time at ON a.AvailableTimeID = at.AvailableTimeID
+          WHERE a.DoctorID = d.DoctorID AND at.ScheduleDate >= CURDATE()) AS UpcomingAppointments
+     FROM doctors d
+     WHERE ? = ''
+        OR LOWER(d.FullName) LIKE ?
+        OR LOWER(d.Email) LIKE ?
+        OR LOWER(IFNULL(d.Specialization, '')) LIKE ?
+     ORDER BY d.FullName ASC
+     LIMIT 50`,
+    [normalized, like, like, like]
+  );
+
+  return doctors;
+}
+
+async function getDoctorProfileForAdmin(doctorId) {
+  const doctors = await execute(
+    `SELECT
+        d.DoctorID,
+        d.FullName,
+        d.Email,
+        d.PhoneNumber,
+        d.Specialization,
+        d.AvatarUrl,
+        d.MaxPatientNumber,
+        d.CurrentPatientNumber,
+        d.CreatedAt,
+        (SELECT COUNT(*) FROM appointments a WHERE a.DoctorID = d.DoctorID) AS TotalAppointments
+     FROM doctors d
+     WHERE d.DoctorID = ?`,
+    [doctorId]
+  );
+
+  return doctors[0] || null;
+}
+
+async function listDoctorAppointmentsForAdmin(doctorId, scope = 'all') {
+  let condition = '';
+  if (scope === 'upcoming') {
+    condition = 'AND at.ScheduleDate >= CURDATE()';
+  } else if (scope === 'history') {
+    condition = 'AND at.ScheduleDate < CURDATE()';
+  }
+
+  return execute(
+    `SELECT
+        a.AppointmentID,
+        a.Status,
+        a.Notes,
+        a.CreatedAt,
+        p.PatientID,
+        p.FullName AS PatientName,
+        p.PhoneNumber,
+        DATE_FORMAT(at.ScheduleDate, '%Y-%m-%d') AS ScheduleDate,
+        TIME_FORMAT(at.StartTime, '%H:%i') AS StartTime,
+        TIME_FORMAT(at.EndTime, '%H:%i') AS EndTime
+     FROM appointments a
+     JOIN patients p ON a.PatientID = p.PatientID
+     JOIN available_time at ON a.AvailableTimeID = at.AvailableTimeID
+     WHERE a.DoctorID = ? ${condition}
+     ORDER BY at.ScheduleDate ${scope === 'history' ? 'DESC' : 'ASC'}, at.StartTime ${
+      scope === 'history' ? 'DESC' : 'ASC'
+    }`,
+    [doctorId]
+  );
 }
 
 module.exports = {
   getOverviewMetrics,
+  searchDoctorsDirectory,
+  getDoctorProfileForAdmin,
+  listDoctorAppointmentsForAdmin,
 };

--- a/backend/src/services/appointmentService.js
+++ b/backend/src/services/appointmentService.js
@@ -235,6 +235,17 @@ async function listAppointmentsForPatient(patientId) {
   );
 }
 
+async function hasDoctorSeenPatient(doctorId, patientId) {
+  const rows = await execute(
+    `SELECT COUNT(*) AS total
+       FROM appointments
+       WHERE DoctorID = ? AND PatientID = ?`,
+    [doctorId, patientId]
+  );
+
+  return (rows[0]?.total || 0) > 0;
+}
+
 async function updateAppointmentStatus(appointmentId, status, notes = null) {
   await execute(
     `UPDATE appointments SET Status = ?, Notes = ?, UpdatedAt = CURRENT_TIMESTAMP WHERE AppointmentID = ?`,
@@ -260,6 +271,7 @@ module.exports = {
   createAvailabilitySlots,
   listAppointmentsForDoctor,
   listAppointmentsForPatient,
+  hasDoctorSeenPatient,
   updateAppointmentStatus,
   getAppointmentById,
   reopenAvailabilitySlot,

--- a/frontend/src/features/admin/components/DoctorDirectoryTab.jsx
+++ b/frontend/src/features/admin/components/DoctorDirectoryTab.jsx
@@ -1,0 +1,324 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+function DoctorDirectoryTab({ token }) {
+  const apiBaseUrl = useMemo(() => {
+    const url = process.env.REACT_APP_API_URL || '';
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+  }, []);
+
+  const [searchValue, setSearchValue] = useState('');
+  const [doctors, setDoctors] = useState([]);
+  const [directoryStatus, setDirectoryStatus] = useState('idle');
+  const [directoryError, setDirectoryError] = useState('');
+  const [selectedDoctorId, setSelectedDoctorId] = useState(null);
+  const [selectedDoctorProfile, setSelectedDoctorProfile] = useState(null);
+  const [upcomingAppointments, setUpcomingAppointments] = useState([]);
+  const [historyAppointments, setHistoryAppointments] = useState([]);
+  const [detailsStatus, setDetailsStatus] = useState('idle');
+  const [detailsError, setDetailsError] = useState('');
+
+  const fetchDoctors = async (query = '') => {
+    if (!token) {
+      return;
+    }
+
+    setDirectoryStatus('loading');
+    setDirectoryError('');
+
+    try {
+      const response = await fetch(
+        `${apiBaseUrl}/api/admin/doctors${query ? `?search=${encodeURIComponent(query)}` : ''}`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error('Unable to load doctor directory.');
+      }
+
+      const data = await response.json();
+      setDoctors(Array.isArray(data) ? data : []);
+      setDirectoryStatus('succeeded');
+      if (data.length && !selectedDoctorId) {
+        setSelectedDoctorId(data[0].DoctorID);
+      }
+    } catch (error) {
+      setDoctors([]);
+      setDirectoryStatus('failed');
+      setDirectoryError(error.message || 'Unable to load doctor directory.');
+    }
+  };
+
+  const fetchDoctorDetails = async (doctorId) => {
+    if (!token || !doctorId) {
+      return;
+    }
+
+    setDetailsStatus('loading');
+    setDetailsError('');
+
+    try {
+      const [profileRes, upcomingRes, historyRes] = await Promise.all([
+        fetch(`${apiBaseUrl}/api/admin/doctors/${doctorId}/profile`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`${apiBaseUrl}/api/admin/doctors/${doctorId}/appointments?scope=upcoming`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+        fetch(`${apiBaseUrl}/api/admin/doctors/${doctorId}/appointments?scope=history`, {
+          headers: { Authorization: `Bearer ${token}` },
+        }),
+      ]);
+
+      if (!profileRes.ok) {
+        throw new Error('Unable to load doctor profile.');
+      }
+      if (!upcomingRes.ok || !historyRes.ok) {
+        throw new Error('Unable to load appointment records.');
+      }
+
+      const profileData = await profileRes.json();
+      const upcomingData = await upcomingRes.json();
+      const historyData = await historyRes.json();
+
+      setSelectedDoctorProfile(profileData);
+      setUpcomingAppointments(Array.isArray(upcomingData) ? upcomingData : []);
+      setHistoryAppointments(Array.isArray(historyData) ? historyData : []);
+      setDetailsStatus('succeeded');
+    } catch (error) {
+      setDetailsStatus('failed');
+      setDetailsError(error.message || 'Unable to load doctor details.');
+      setSelectedDoctorProfile(null);
+      setUpcomingAppointments([]);
+      setHistoryAppointments([]);
+    }
+  };
+
+  useEffect(() => {
+    if (directoryStatus === 'idle' && token) {
+      fetchDoctors();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [directoryStatus, token]);
+
+  useEffect(() => {
+    if (selectedDoctorId) {
+      fetchDoctorDetails(selectedDoctorId);
+    } else {
+      setSelectedDoctorProfile(null);
+      setUpcomingAppointments([]);
+      setHistoryAppointments([]);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedDoctorId]);
+
+  const handleSearchSubmit = (event) => {
+    event.preventDefault();
+    fetchDoctors(searchValue.trim());
+  };
+
+  const formatSchedule = (appointment) => {
+    if (!appointment.ScheduleDate || !appointment.StartTime) {
+      return 'Unknown schedule';
+    }
+
+    try {
+      return new Date(`${appointment.ScheduleDate}T${appointment.StartTime}`).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    } catch (error) {
+      return `${appointment.ScheduleDate} ${appointment.StartTime}`;
+    }
+  };
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-brand-primary">Doctor directory</h2>
+          <p className="text-sm text-slate-600">
+            Search doctors, review their profiles, and monitor appointment workloads from a single workspace.
+          </p>
+        </div>
+        <form onSubmit={handleSearchSubmit} className="flex w-full max-w-md gap-2">
+          <input
+            type="search"
+            value={searchValue}
+            onChange={(event) => setSearchValue(event.target.value)}
+            placeholder="Search by name, email, or specialization"
+            className="flex-1 rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-700 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+          />
+          <button
+            type="submit"
+            className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark"
+          >
+            Search
+          </button>
+        </form>
+      </header>
+
+      {directoryStatus === 'failed' ? (
+        <div className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+          {directoryError}
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[minmax(0,260px)_1fr]">
+        <aside className="flex flex-col gap-3">
+          <h3 className="text-sm font-semibold text-slate-600">Doctors ({doctors.length})</h3>
+          <div className="flex flex-col gap-2">
+            {directoryStatus === 'loading' ? (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                Loading directory…
+              </div>
+            ) : null}
+            {directoryStatus === 'succeeded' && !doctors.length ? (
+              <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-6 text-center text-sm text-slate-500">
+                No doctors match this search.
+              </div>
+            ) : null}
+            {doctors.map((doctor) => {
+              const isActive = doctor.DoctorID === selectedDoctorId;
+              return (
+                <button
+                  key={doctor.DoctorID}
+                  type="button"
+                  onClick={() => setSelectedDoctorId(doctor.DoctorID)}
+                  className={`flex flex-col rounded-2xl border px-4 py-3 text-left text-sm transition ${
+                    isActive
+                      ? 'border-brand-primary bg-brand-secondary/60 text-brand-dark shadow-sm'
+                      : 'border-slate-200 bg-white text-slate-700 hover:border-brand-primary/60 hover:text-brand-primary'
+                  }`}
+                >
+                  <span className="font-semibold">{doctor.FullName}</span>
+                  <span className="text-xs text-slate-500">{doctor.Specialization || 'General medicine'}</span>
+                  <span className="mt-1 text-xs text-slate-500">
+                    Upcoming: {doctor.UpcomingAppointments || 0} · Total appointments: {doctor.TotalAppointments || 0}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        <article className="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-card backdrop-blur">
+          {detailsStatus === 'loading' ? (
+            <div className="flex min-h-[12rem] items-center justify-center text-slate-500">Loading doctor details…</div>
+          ) : null}
+          {detailsStatus === 'failed' ? (
+            <div className="flex min-h-[12rem] flex-col items-center justify-center gap-3 text-rose-600">
+              <span>{detailsError}</span>
+              <button
+                type="button"
+                onClick={() => fetchDoctorDetails(selectedDoctorId)}
+                className="rounded-full border border-rose-300 px-4 py-2 text-sm font-semibold text-rose-600 hover:bg-rose-50"
+              >
+                Retry loading
+              </button>
+            </div>
+          ) : null}
+          {detailsStatus !== 'loading' && !selectedDoctorProfile ? (
+            <div className="flex min-h-[12rem] items-center justify-center text-slate-500">
+              Select a doctor to view profile and appointments.
+            </div>
+          ) : null}
+          {detailsStatus === 'succeeded' && selectedDoctorProfile ? (
+            <div className="flex flex-col gap-6">
+              <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-slate-50 p-6 md:flex-row md:items-start md:justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold text-brand-primary">{selectedDoctorProfile.FullName}</h3>
+                  <p className="text-sm text-slate-600">{selectedDoctorProfile.Specialization || 'General medicine'}</p>
+                  <dl className="mt-3 grid gap-2 text-xs text-slate-600">
+                    <div className="flex gap-2">
+                      <dt className="font-semibold text-slate-500">Email:</dt>
+                      <dd>{selectedDoctorProfile.Email || 'Not provided'}</dd>
+                    </div>
+                    <div className="flex gap-2">
+                      <dt className="font-semibold text-slate-500">Phone:</dt>
+                      <dd>{selectedDoctorProfile.PhoneNumber || 'Not provided'}</dd>
+                    </div>
+                    <div className="flex gap-2">
+                      <dt className="font-semibold text-slate-500">Capacity:</dt>
+                      <dd>
+                        {selectedDoctorProfile.CurrentPatientNumber || 0} /{' '}
+                        {selectedDoctorProfile.MaxPatientNumber || 0} active patients
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+                <div className="rounded-2xl border border-brand-primary/20 bg-white px-4 py-3 text-xs text-slate-600 shadow-inner">
+                  <p className="font-semibold uppercase tracking-wide text-brand-primary">Snapshot</p>
+                  <ul className="mt-2 space-y-1">
+                    <li>Total appointments: {selectedDoctorProfile.TotalAppointments || 0}</li>
+                    <li>Upcoming appointments: {upcomingAppointments.length}</li>
+                    <li>Past appointments: {historyAppointments.length}</li>
+                  </ul>
+                </div>
+              </div>
+
+              <div className="grid gap-6 lg:grid-cols-2">
+                <div className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                  <h4 className="text-sm font-semibold text-brand-primary">Upcoming appointments</h4>
+                  <ul className="mt-3 space-y-3 text-xs text-slate-600">
+                    {upcomingAppointments.length ? (
+                      upcomingAppointments.map((appointment) => (
+                        <li key={appointment.AppointmentID} className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                          <p className="font-semibold text-brand-dark">{appointment.PatientName}</p>
+                          <p>{formatSchedule(appointment)}</p>
+                          <p>Status: {appointment.Status?.toUpperCase() || 'PENDING'}</p>
+                          <p>Notes: {appointment.Notes || '—'}</p>
+                        </li>
+                      ))
+                    ) : (
+                      <li className="rounded-2xl border border-dashed border-slate-200 p-3 text-center text-slate-400">
+                        No upcoming appointments.
+                      </li>
+                    )}
+                  </ul>
+                </div>
+
+                <div className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                  <h4 className="text-sm font-semibold text-brand-primary">Appointment history</h4>
+                  <ul className="mt-3 space-y-3 text-xs text-slate-600">
+                    {historyAppointments.length ? (
+                      historyAppointments.map((appointment) => (
+                        <li key={appointment.AppointmentID} className="rounded-2xl border border-slate-200 bg-slate-50 p-3">
+                          <p className="font-semibold text-brand-dark">{appointment.PatientName}</p>
+                          <p>{formatSchedule(appointment)}</p>
+                          <p>Status: {appointment.Status?.toUpperCase() || 'PENDING'}</p>
+                          <p>Notes: {appointment.Notes || '—'}</p>
+                        </li>
+                      ))
+                    ) : (
+                      <li className="rounded-2xl border border-dashed border-slate-200 p-3 text-center text-slate-400">
+                        No historical appointments found.
+                      </li>
+                    )}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </article>
+      </div>
+    </section>
+  );
+}
+
+DoctorDirectoryTab.propTypes = {
+  token: PropTypes.string,
+};
+
+DoctorDirectoryTab.defaultProps = {
+  token: '',
+};
+
+export default DoctorDirectoryTab;

--- a/frontend/src/features/admin/components/HomeHeroTab.jsx
+++ b/frontend/src/features/admin/components/HomeHeroTab.jsx
@@ -1,0 +1,267 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+
+const defaultHeroState = {
+  eyebrow: '',
+  title: '',
+  subtitle: '',
+  imageUrl: '',
+  ctaLabel: '',
+};
+
+function HomeHeroTab({ token }) {
+  const apiBaseUrl = useMemo(() => {
+    const url = process.env.REACT_APP_API_URL || '';
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+  }, []);
+  const [form, setForm] = useState(defaultHeroState);
+  const [status, setStatus] = useState('idle');
+  const [feedback, setFeedback] = useState(null);
+
+  useEffect(() => {
+    if (!token) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHero = async () => {
+      setStatus('loading');
+      setFeedback(null);
+      try {
+        const response = await fetch(`${apiBaseUrl}/api/admin/content/home-hero`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('Unable to load homepage hero content.');
+        }
+
+        const data = await response.json();
+        if (isMounted) {
+          setForm({
+            eyebrow: data.eyebrow || '',
+            title: data.title || '',
+            subtitle: data.subtitle || '',
+            imageUrl: data.imageUrl || '',
+            ctaLabel: data.ctaLabel || '',
+          });
+          setStatus('succeeded');
+        }
+      } catch (error) {
+        if (isMounted) {
+          setStatus('failed');
+          setFeedback({ type: 'error', message: error.message || 'Unable to load hero content.' });
+        }
+      }
+    };
+
+    loadHero();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [apiBaseUrl, token]);
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!token) {
+      setFeedback({ type: 'error', message: 'Authentication token missing.' });
+      return;
+    }
+
+    setFeedback(null);
+    setStatus('saving');
+
+    try {
+      const response = await fetch(`${apiBaseUrl}/api/admin/content/home-hero`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+
+      if (!response.ok) {
+        const payload = await response.json().catch(() => ({}));
+        throw new Error(payload.error || payload.message || 'Unable to update hero content.');
+      }
+
+      const data = await response.json();
+      setForm({
+        eyebrow: data.eyebrow || '',
+        title: data.title || '',
+        subtitle: data.subtitle || '',
+        imageUrl: data.imageUrl || '',
+        ctaLabel: data.ctaLabel || '',
+      });
+      setStatus('succeeded');
+      setFeedback({ type: 'success', message: 'Homepage hero content updated successfully.' });
+    } catch (error) {
+      setStatus('failed');
+      setFeedback({ type: 'error', message: error.message || 'Unable to update hero content.' });
+    }
+  };
+
+  const heroPreviewStyle = form.imageUrl
+    ? {
+        backgroundImage: `linear-gradient(135deg, rgba(7, 116, 105, 0.82), rgba(15, 23, 42, 0.78)), url(${form.imageUrl})`,
+      }
+    : {
+        backgroundImage: 'linear-gradient(135deg, rgba(7, 116, 105, 0.82), rgba(15, 23, 42, 0.78))',
+      };
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold text-brand-primary">Homepage hero</h2>
+          <p className="text-sm text-slate-600">
+            Update the landing banner image, headline, and call-to-action shown on the public homepage.
+          </p>
+        </div>
+        {status === 'loading' ? (
+          <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500">Loading…</span>
+        ) : null}
+      </header>
+
+      {feedback ? (
+        <div
+          className={`mt-4 rounded-xl border px-4 py-3 text-sm ${
+            feedback.type === 'success'
+              ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+              : 'border-rose-200 bg-rose-50 text-rose-700'
+          }`}
+        >
+          {feedback.message}
+        </div>
+      ) : null}
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Eyebrow label
+            <input
+              type="text"
+              name="eyebrow"
+              value={form.eyebrow}
+              onChange={handleChange}
+              placeholder="Example: Coordinated care, on your schedule"
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Headline
+            <input
+              type="text"
+              name="title"
+              value={form.title}
+              onChange={handleChange}
+              placeholder="Expert specialists and secure records in one hospital hub"
+              required
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Supporting text
+            <textarea
+              name="subtitle"
+              value={form.subtitle}
+              onChange={handleChange}
+              placeholder="Describe how patients benefit from the platform"
+              rows={4}
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Call-to-action label
+            <input
+              type="text"
+              name="ctaLabel"
+              value={form.ctaLabel}
+              onChange={handleChange}
+              placeholder="Book an appointment"
+              required
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm font-medium text-slate-700">
+            Background image URL
+            <input
+              type="url"
+              name="imageUrl"
+              value={form.imageUrl}
+              onChange={handleChange}
+              placeholder="https://"
+              className="rounded-2xl border border-slate-200 px-4 py-3 text-sm text-slate-900 shadow-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary/30"
+            />
+          </label>
+
+          <div className="flex flex-wrap gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={status === 'saving'}
+              className="inline-flex items-center justify-center rounded-full bg-brand-primary px-6 py-2 text-sm font-semibold text-white shadow hover:bg-brand-dark disabled:cursor-not-allowed disabled:bg-slate-300"
+            >
+              {status === 'saving' ? 'Saving…' : 'Save hero content'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setForm(defaultHeroState)}
+              className="inline-flex items-center justify-center rounded-full border border-slate-200 px-6 py-2 text-sm font-semibold text-slate-600 transition hover:border-brand-primary hover:text-brand-primary"
+            >
+              Reset fields
+            </button>
+          </div>
+        </form>
+
+        <div className="flex flex-col gap-4">
+          <p className="text-sm font-semibold text-slate-600">Live preview</p>
+          <div
+            className="relative overflow-hidden rounded-[32px] border border-slate-200 text-white shadow-soft"
+            style={heroPreviewStyle}
+          >
+            <div className="absolute inset-0 bg-cover bg-center" aria-hidden="true" style={heroPreviewStyle} />
+            <div className="relative z-10 flex flex-col gap-4 p-8">
+              <span className="inline-flex items-center rounded-full bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/80">
+                {form.eyebrow || 'Eyebrow label'}
+              </span>
+              <h3 className="text-2xl font-semibold sm:text-3xl">{form.title || 'Hero headline goes here'}</h3>
+              <p className="text-sm text-white/90">
+                {form.subtitle || 'Use this space to describe how patients can use the platform to manage appointments and records.'}
+              </p>
+              <button
+                type="button"
+                className="w-max rounded-full bg-white px-5 py-2 text-sm font-semibold text-brand-primary shadow-soft"
+                disabled
+              >
+                {form.ctaLabel || 'Book an appointment'}
+              </button>
+            </div>
+          </div>
+          <p className="text-xs text-slate-500">
+            The booking button always links to the public booking page. Provide a compelling label to encourage patients to book.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+HomeHeroTab.propTypes = {
+  token: PropTypes.string,
+};
+
+HomeHeroTab.defaultProps = {
+  token: '',
+};
+
+export default HomeHeroTab;

--- a/frontend/src/features/admin/pages/AdminDashboard.jsx
+++ b/frontend/src/features/admin/pages/AdminDashboard.jsx
@@ -6,13 +6,17 @@ import DoctorApplicationsTab from '../components/DoctorApplicationsTab';
 import AboutContentTab from '../components/AboutContentTab';
 import ServicePackagesTab from '../components/ServicePackagesTab';
 import SiteSettingsTab from '../components/SiteSettingsTab';
+import HomeHeroTab from '../components/HomeHeroTab';
+import DoctorDirectoryTab from '../components/DoctorDirectoryTab';
 
 const tabs = [
   { id: 'overview', label: 'Overview' },
   { id: 'doctor-applications', label: 'Doctor Applications' },
   { id: 'about', label: 'About Page' },
   { id: 'packages', label: 'Service Packages' },
+  { id: 'home-hero', label: 'Homepage Hero' },
   { id: 'site-settings', label: 'Site Settings' },
+  { id: 'doctor-directory', label: 'Doctor Directory' },
 ];
 
 function AdminDashboard() {
@@ -59,6 +63,7 @@ function AdminDashboard() {
       {activeTab === 'doctor-applications' ? <DoctorApplicationsTab token={auth.token} /> : null}
       {activeTab === 'about' ? <AboutContentTab token={auth.token} /> : null}
       {activeTab === 'packages' ? <ServicePackagesTab token={auth.token} /> : null}
+      {activeTab === 'home-hero' ? <HomeHeroTab token={auth.token} /> : null}
       {activeTab === 'site-settings' ? (
         <SiteSettingsTab
           token={auth.token}
@@ -67,6 +72,7 @@ function AdminDashboard() {
           setCachedSiteSettings={setCachedSiteSettings}
         />
       ) : null}
+      {activeTab === 'doctor-directory' ? <DoctorDirectoryTab token={auth.token} /> : null}
     </div>
   );
 }

--- a/frontend/src/features/staff/components/DoctorAppointmentsOverview.jsx
+++ b/frontend/src/features/staff/components/DoctorAppointmentsOverview.jsx
@@ -26,6 +26,7 @@ function DoctorAppointmentsOverview({
   statusFeedback,
   onUpdateStatus,
   onComposeReport,
+  onViewPatientHistory,
 }) {
   const navigate = useNavigate();
 
@@ -69,6 +70,12 @@ function DoctorAppointmentsOverview({
               ? appointment.PatientDocuments
               : [];
 
+            const viewHistory = () => {
+              if (onViewPatientHistory) {
+                onViewPatientHistory(appointment.PatientID);
+              }
+            };
+
             return (
               <article
                 key={appointment.AppointmentID}
@@ -76,7 +83,13 @@ function DoctorAppointmentsOverview({
               >
                 <div className="space-y-2">
                   <div>
-                    <h3 className="text-sm font-semibold text-slate-900">{appointment.PatientName}</h3>
+                    <button
+                      type="button"
+                      onClick={viewHistory}
+                      className="text-left text-sm font-semibold text-brand-primary transition hover:text-brand-dark"
+                    >
+                      {appointment.PatientName}
+                    </button>
                     <p className="text-xs text-slate-600">Phone: {appointment.PhoneNumber || 'N/A'}</p>
                     <p className="mt-1 text-xs text-slate-500">
                       {formatAppointmentDate(appointment.ScheduleDate, appointment.StartTime)} — {appointment.EndTime}
@@ -169,6 +182,13 @@ function DoctorAppointmentsOverview({
                         Send report
                       </button>
                     ) : null}
+                    <button
+                      type="button"
+                      onClick={viewHistory}
+                      className="rounded-full border border-brand-primary/40 px-3 py-2 font-semibold text-brand-primary transition hover:bg-brand-primary hover:text-white"
+                    >
+                      View history
+                    </button>
                   </div>
                 </div>
               </article>
@@ -205,11 +225,13 @@ DoctorAppointmentsOverview.propTypes = {
   }),
   onUpdateStatus: PropTypes.func.isRequired,
   onComposeReport: PropTypes.func,
+  onViewPatientHistory: PropTypes.func,
 };
 
 DoctorAppointmentsOverview.defaultProps = {
   statusFeedback: null,
   onComposeReport: undefined,
+  onViewPatientHistory: undefined,
 };
 
 export default DoctorAppointmentsOverview;

--- a/frontend/src/features/staff/components/DoctorPatientHistory.jsx
+++ b/frontend/src/features/staff/components/DoctorPatientHistory.jsx
@@ -1,0 +1,262 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useNavigate, useParams } from 'react-router-dom';
+
+function DoctorPatientHistory({ token, doctorId }) {
+  const { patientId } = useParams();
+  const navigate = useNavigate();
+  const apiBaseUrl = useMemo(() => {
+    const url = process.env.REACT_APP_API_URL || '';
+    return url.endsWith('/') ? url.slice(0, -1) : url;
+  }, []);
+  const [status, setStatus] = useState('loading');
+  const [error, setError] = useState('');
+  const [history, setHistory] = useState(null);
+
+  useEffect(() => {
+    if (!token || !doctorId || !patientId || status !== 'loading') {
+      return;
+    }
+
+    let isMounted = true;
+
+    const loadHistory = async () => {
+      setStatus('loading');
+      setError('');
+      try {
+        const response = await fetch(
+          `${apiBaseUrl}/api/doctors/${doctorId}/patients/${patientId}/history`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (!response.ok) {
+          const payload = await response.json().catch(() => ({}));
+          throw new Error(payload.message || 'Unable to load patient history.');
+        }
+
+        const data = await response.json();
+        if (isMounted) {
+          setHistory(data);
+          setStatus('succeeded');
+        }
+      } catch (err) {
+        if (isMounted) {
+          setStatus('failed');
+          setError(err.message || 'Unable to load patient history.');
+        }
+      }
+    };
+
+    loadHistory();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [apiBaseUrl, doctorId, patientId, token, status]);
+
+  const formatSchedule = (appointment) => {
+    if (!appointment.ScheduleDate || !appointment.StartTime) {
+      return 'Unknown schedule';
+    }
+
+    try {
+      return new Date(`${appointment.ScheduleDate}T${appointment.StartTime}`).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+    } catch (error) {
+      return `${appointment.ScheduleDate} ${appointment.StartTime}`;
+    }
+  };
+
+  const sortedAppointments = history?.appointments
+    ? [...history.appointments].sort(
+        (a, b) => new Date(`${b.ScheduleDate}T${b.StartTime}`) - new Date(`${a.ScheduleDate}T${a.StartTime}`)
+      )
+    : [];
+
+  const documents = Array.isArray(history?.documents) ? history.documents : [];
+  const reports = Array.isArray(history?.reports) ? history.reports : [];
+
+  return (
+    <section className="rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-card backdrop-blur">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <button
+            type="button"
+            onClick={() => navigate('../', { replace: false })}
+            className="inline-flex items-center gap-2 text-sm font-semibold text-brand-primary hover:text-brand-dark"
+          >
+            ← Back to appointments
+          </button>
+          <h2 className="mt-3 text-xl font-semibold text-brand-primary">Patient medical history</h2>
+          <p className="text-sm text-slate-600">
+            Review appointments, documents, and reports shared with this patient.
+          </p>
+        </div>
+      </div>
+
+      {status === 'loading' ? (
+        <div className="mt-8 flex min-h-[12rem] items-center justify-center text-slate-500">
+          Loading patient timeline…
+        </div>
+      ) : null}
+
+      {status === 'failed' ? (
+        <div className="mt-8 flex min-h-[12rem] flex-col items-center justify-center gap-3 text-rose-600">
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => setStatus('loading')}
+            className="rounded-full border border-rose-300 px-4 py-2 text-sm font-semibold text-rose-600 hover:bg-rose-50"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {status === 'succeeded' && history ? (
+        <div className="mt-8 space-y-8">
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6">
+            <h3 className="text-lg font-semibold text-brand-primary">{history.patient.FullName}</h3>
+            <dl className="mt-3 grid gap-2 text-xs text-slate-600 sm:grid-cols-2">
+              <div className="flex gap-2">
+                <dt className="font-semibold text-slate-500">Email:</dt>
+                <dd>{history.patient.Email || 'Not provided'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-semibold text-slate-500">Phone:</dt>
+                <dd>{history.patient.PhoneNumber || 'Not provided'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-semibold text-slate-500">Gender:</dt>
+                <dd>{history.patient.Gender || 'Not provided'}</dd>
+              </div>
+              <div className="flex gap-2">
+                <dt className="font-semibold text-slate-500">NID:</dt>
+                <dd>{history.patient.NidNumber || 'Not provided'}</dd>
+              </div>
+              <div className="flex gap-2 sm:col-span-2">
+                <dt className="font-semibold text-slate-500">Address:</dt>
+                <dd>{history.patient.Address || 'Not provided'}</dd>
+              </div>
+            </dl>
+          </div>
+
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2 rounded-3xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+              <h3 className="text-sm font-semibold text-brand-primary">Appointment timeline</h3>
+              <ul className="mt-4 space-y-4 text-sm text-slate-600">
+                {sortedAppointments.length ? (
+                  sortedAppointments.map((appointment) => (
+                    <li key={appointment.AppointmentID} className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="font-semibold text-brand-dark">
+                          {formatSchedule(appointment)} with {appointment.DoctorName}
+                        </p>
+                        <span className="rounded-full bg-brand-secondary/60 px-3 py-1 text-xs font-semibold text-brand-dark">
+                          {appointment.Status?.toUpperCase() || 'PENDING'}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-xs text-slate-500">Notes: {appointment.Notes || 'No notes provided.'}</p>
+                    </li>
+                  ))
+                ) : (
+                  <li className="rounded-2xl border border-dashed border-slate-200 p-4 text-center text-slate-400">
+                    No appointments recorded for this patient.
+                  </li>
+                )}
+              </ul>
+            </div>
+
+            <div className="flex flex-col gap-6">
+              <div className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <h4 className="text-sm font-semibold text-brand-primary">Uploaded documents</h4>
+                <ul className="mt-3 space-y-2 text-xs text-slate-600">
+                  {documents.length ? (
+                    documents.map((document) => (
+                      <li key={document.DocumentID} className="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                        <span className="truncate font-medium" title={document.DocumentName}>
+                          {document.DocumentName}
+                        </span>
+                        <a
+                          href={document.FileUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="shrink-0 rounded-full border border-brand-primary px-3 py-1 font-semibold text-brand-primary transition hover:bg-brand-primary hover:text-white"
+                        >
+                          View
+                        </a>
+                      </li>
+                    ))
+                  ) : (
+                    <li className="rounded-2xl border border-dashed border-slate-200 px-3 py-4 text-center text-slate-400">
+                      No documents uploaded yet.
+                    </li>
+                  )}
+                </ul>
+              </div>
+
+              <div className="rounded-3xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <h4 className="text-sm font-semibold text-brand-primary">Doctor reports</h4>
+                <ul className="mt-3 space-y-2 text-xs text-slate-600">
+                  {reports.length ? (
+                    reports.map((report) => (
+                      <li key={report.ReportID} className="flex flex-col gap-1 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2">
+                        <span className="font-semibold text-brand-dark">{report.Title}</span>
+                        <span>By {report.DoctorName}</span>
+                        <span className="text-[11px] text-slate-500">
+                          {new Date(report.CreatedAt).toLocaleString('en-US', {
+                            month: 'short',
+                            day: 'numeric',
+                            year: 'numeric',
+                            hour: 'numeric',
+                            minute: '2-digit',
+                          })}
+                        </span>
+                        {report.FileUrl ? (
+                          <a
+                            href={report.FileUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="w-max rounded-full border border-brand-primary px-3 py-1 font-semibold text-brand-primary transition hover:bg-brand-primary hover:text-white"
+                          >
+                            View report
+                          </a>
+                        ) : null}
+                        {report.Description ? <p className="text-[11px] text-slate-500">{report.Description}</p> : null}
+                      </li>
+                    ))
+                  ) : (
+                    <li className="rounded-2xl border border-dashed border-slate-200 px-3 py-4 text-center text-slate-400">
+                      No reports submitted yet.
+                    </li>
+                  )}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+DoctorPatientHistory.propTypes = {
+  token: PropTypes.string,
+  doctorId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+};
+
+DoctorPatientHistory.defaultProps = {
+  token: '',
+  doctorId: null,
+};
+
+export default DoctorPatientHistory;

--- a/frontend/src/features/staff/pages/StaffPortal.jsx
+++ b/frontend/src/features/staff/pages/StaffPortal.jsx
@@ -1,15 +1,17 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { NavLink, Navigate, Route, Routes } from 'react-router-dom';
+import { NavLink, Navigate, Route, Routes, useNavigate } from 'react-router-dom';
 import { FaUserMd } from 'react-icons/fa';
 import { AuthContext } from '../../auth/context/AuthContext';
 import DoctorAppointmentsOverview from '../components/DoctorAppointmentsOverview';
 import DoctorReportCenter from '../components/DoctorReportCenter';
 import DoctorAvailabilityPlanner from '../components/DoctorAvailabilityPlanner';
 import DoctorProfileSettings from '../components/DoctorProfileSettings';
+import DoctorPatientHistory from '../components/DoctorPatientHistory';
 
 function StaffPortal() {
   const { auth } = useContext(AuthContext);
   const doctorId = auth.user?.id;
+  const navigate = useNavigate();
   const apiBaseUrl = (process.env.REACT_APP_API_URL || '').replace(/\/$/, '');
 
   const [doctorProfile, setDoctorProfile] = useState(null);
@@ -456,6 +458,13 @@ function StaffPortal() {
     }));
   };
 
+  const handleViewPatientHistory = (patientId) => {
+    if (!patientId) {
+      return;
+    }
+    navigate(`patients/${patientId}`);
+  };
+
   const handleReportSubmit = async (event) => {
     event.preventDefault();
     if (!reportForm.appointmentId || !reportForm.title || !reportForm.file) {
@@ -667,6 +676,7 @@ function StaffPortal() {
               statusFeedback={statusFeedback}
               onUpdateStatus={handleAppointmentStatus}
               onComposeReport={handleStartReport}
+              onViewPatientHistory={handleViewPatientHistory}
             />
           }
         />
@@ -719,6 +729,10 @@ function StaffPortal() {
               passwordFeedback={passwordFeedback}
             />
           }
+        />
+        <Route
+          path="patients/:patientId"
+          element={<DoctorPatientHistory token={auth.token} doctorId={doctorId} />}
         />
         <Route path="*" element={<Navigate to="." replace />} />
       </Routes>


### PR DESCRIPTION
## Summary
- fix service package item cleanup by normalizing identifiers before issuing bulk deletes
- expose editable homepage hero content for admins and render it on the public landing page
- add an admin doctor directory with appointment history plus a doctor-facing patient history view and linked specialist/doctor booking selectors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e28a6499988322a999b1824df8767a