### PR TITLE
Add specialists page and clean comments

### DIFF
--- a/backend/populateAvailableTime.js
+++ b/backend/populateAvailableTime.js
@@ -1,7 +1,5 @@
 const mysql = require('mysql2/promise');
 const config = require('./src/config/env');
-
-// Utility script to seed random availability slots for doctors.
 function formatDate(date) {
   const year = date.getFullYear();
   const month = (`0${date.getMonth() + 1}`).slice(-2);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -10,21 +10,13 @@ const adminRoutes = require('./routes/adminRoutes');
 const contentRoutes = require('./routes/contentRoutes');
 const errorHandler = require('./middleware/errorHandler');
 const publicPatientRoutes = require('./routes/publicPatientRoutes');
-
-// Create and configure the Express application instance.
 const app = express();
-
-// Apply security headers, enable CORS, and parse JSON payloads with a sensible limit.
 app.use(helmet());
 app.use(cors());
 app.use(express.json({ limit: '10kb' }));
-
-// Lightweight health-check endpoint for monitoring.
 app.get('/health', (_req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
-
-// Register application routes.
 app.use('/api', authRoutes);
 app.use('/api/doctors', doctorRoutes);
 app.use('/api/patients', patientRoutes);
@@ -32,13 +24,9 @@ app.use('/api/appointments', appointmentRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/content', contentRoutes);
 app.use('/api/patient-access', publicPatientRoutes);
-
-// Fallback handler for unmatched routes to avoid Express default HTML responses.
 app.use((req, res) => {
   res.status(404).json({ message: 'Route not found' });
 });
-
-// Centralized error handler ensures consistent JSON error responses.
 app.use(errorHandler);
 
 module.exports = { app, config };

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -1,7 +1,6 @@
 const mysql = require('mysql2/promise');
 const config = require('./env');
 
-// Shared MySQL connection pool used across the application.
 const pool = mysql.createPool({
   host: config.database.host,
   port: config.database.port,
@@ -34,7 +33,6 @@ async function waitForAvailability(
         connection.release();
       }
       if (attempt < attempts) {
-        // eslint-disable-next-line no-console
         console.warn(
           `Database connection failed (attempt ${attempt}/${attempts}). Retrying in ${delay}ms...`,
           error.message

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -1,6 +1,5 @@
 const dotenv = require('dotenv');
 
-// Load environment variables from the .env file once at application boot.
 dotenv.config();
 
 const requiredVariables = ['JWT_SECRET'];

--- a/backend/src/config/storage.js
+++ b/backend/src/config/storage.js
@@ -11,7 +11,6 @@ const minioClient = new Client({
 });
 
 ensureBucketExists(minioClient, config.storage.bucket).catch((error) => {
-  // eslint-disable-next-line no-console
   console.error('Unable to verify MinIO bucket:', error.message);
 });
 

--- a/backend/src/controllers/appointmentController.js
+++ b/backend/src/controllers/appointmentController.js
@@ -3,8 +3,6 @@ const config = require('../config/env');
 const { getAvailableTimes, bookAppointment } = require('../services/appointmentService');
 const { createPatient, savePatientDocument } = require('../services/patientService');
 const { storeFile } = require('../services/storageService');
-
-// Lists available appointment slots for the provided doctor identifier.
 async function getAvailableTimesHandler(req, res) {
   const doctorIdParam = req.query.doctorId;
   const doctorId = Number.parseInt(doctorIdParam, 10);
@@ -50,21 +48,16 @@ async function persistDocuments(patientId, appointmentId, files = []) {
   }
 
   const stored = [];
-  // eslint-disable-next-line no-restricted-syntax
   for (const file of files) {
-    // eslint-disable-next-line no-await-in-loop
     const url = await storeFile(file, 'patient-documents');
     if (url) {
       stored.push({ name: file.originalname, url });
-      // eslint-disable-next-line no-await-in-loop
       await savePatientDocument(patientId, file.originalname, url, appointmentId);
     }
   }
 
   return stored;
 }
-
-// Books an appointment, creating a patient account when the request is anonymous.
 async function bookAppointmentHandler(req, res) {
   const { availableTimeID, notes = '' } = req.body;
   const slotId = Number.parseInt(availableTimeID, 10);

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -2,8 +2,6 @@ const jwt = require('jsonwebtoken');
 const bcrypt = require('bcryptjs');
 const config = require('../config/env');
 const { findUserByEmail } = require('../services/userService');
-
-// Authenticates a user and issues a signed JWT using the stored role metadata.
 async function signIn(req, res) {
   const { email, password } = req.body;
 
@@ -54,8 +52,6 @@ async function signIn(req, res) {
     },
   });
 }
-
-// Stateless logout endpoint retained for API symmetry.
 function logout(_req, res) {
   return res.json({ message: 'Logout successful' });
 }

--- a/backend/src/controllers/doctorController.js
+++ b/backend/src/controllers/doctorController.js
@@ -25,14 +25,10 @@ const {
   listPatientDocuments,
   listPatientReports,
 } = require('../services/patientService');
-
-// Returns the catalog of doctors available in the clinic.
 async function getDoctors(_req, res) {
   const doctors = await listDoctors();
   return res.json(doctors);
 }
-
-// Returns upcoming available time slots for a specific doctor.
 async function getDoctorAvailability(req, res) {
   const doctorId = Number.parseInt(req.params.id, 10);
 
@@ -64,8 +60,6 @@ async function getDoctorAvailabilityForManagement(req, res) {
   const availability = await listAvailabilityForDoctorManagement(doctorId);
   return res.json(availability);
 }
-
-// Provides upcoming appointments for the authenticated doctor.
 async function getDoctorAppointments(req, res) {
   const { id } = req.params;
 

--- a/backend/src/controllers/patientController.js
+++ b/backend/src/controllers/patientController.js
@@ -10,8 +10,6 @@ const {
 } = require('../services/patientService');
 const { listAppointmentsForPatient } = require('../services/appointmentService');
 const { storeFile } = require('../services/storageService');
-
-// Registers a new patient and associates them with a doctor if capacity allows.
 async function registerPatient(req, res) {
   const { fullName, birthdate, gender, phoneNumber, email, password, address, nidNumber } = req.body;
 
@@ -27,9 +25,7 @@ async function registerPatient(req, res) {
   try {
     const uploadedRecords = [];
     const files = req.files?.medicalRecords || [];
-    // eslint-disable-next-line no-restricted-syntax
     for (const file of files) {
-      // eslint-disable-next-line no-await-in-loop
       const url = await storeFile(file, 'patient-documents');
       uploadedRecords.push({ name: file.originalname, url });
     }
@@ -54,14 +50,10 @@ async function registerPatient(req, res) {
     throw error;
   }
 }
-
-// Lists all registered patients. Requires authentication via middleware.
 async function getPatients(_req, res) {
   const patients = await listPatients();
   return res.json(patients);
 }
-
-// Retrieves a single patient record by identifier.
 async function getPatientByIdHandler(req, res) {
   const { id } = req.params;
 

--- a/backend/src/database/query.js
+++ b/backend/src/database/query.js
@@ -1,12 +1,10 @@
 const pool = require('../config/database');
 
-// Execute a single query using the shared connection pool.
 async function execute(query, params = []) {
   const [rows] = await pool.execute(query, params);
   return rows;
 }
 
-// Helper to run a series of statements within a transaction.
 async function transaction(callback) {
   const connection = await pool.getConnection();
   try {

--- a/backend/src/database/schema.js
+++ b/backend/src/database/schema.js
@@ -2,7 +2,6 @@ const bcrypt = require('bcryptjs');
 const { execute } = require('./query');
 const { migrateMissingPatientUsers } = require('../services/userService');
 
-// Ensures the database schema exists before the application handles requests.
 async function ensureSchema() {
   await createDoctorsTable();
   await createPatientsTable();

--- a/backend/src/middleware/authenticate.js
+++ b/backend/src/middleware/authenticate.js
@@ -1,7 +1,5 @@
 const jwt = require('jsonwebtoken');
 const config = require('../config/env');
-
-// Verifies JWT bearer tokens and attaches the payload to the request context.
 function authenticateToken(req, res, next) {
   const authorizationHeader = req.headers.authorization;
   if (!authorizationHeader?.startsWith('Bearer ')) {

--- a/backend/src/middleware/authenticateOptional.js
+++ b/backend/src/middleware/authenticateOptional.js
@@ -1,7 +1,5 @@
 const jwt = require('jsonwebtoken');
 const config = require('../config/env');
-
-// Attempts to authenticate the incoming request but allows anonymous access.
 function authenticateOptional(req, _res, next) {
   const authorizationHeader = req.headers.authorization;
 

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,6 +1,4 @@
 function errorHandler(err, req, res, next) {
-  // Log errors to help troubleshooting without leaking implementation details to clients.
-  // eslint-disable-next-line no-console
   console.error('Unhandled error:', err);
 
   if (res.headersSent) {

--- a/backend/src/routes/appointmentRoutes.js
+++ b/backend/src/routes/appointmentRoutes.js
@@ -9,7 +9,6 @@ const {
 
 const router = Router();
 
-// Appointment scheduling endpoints.
 router.get('/available-times', authenticateOptional, asyncHandler(getAvailableTimesHandler));
 router.post(
   '/book',

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -4,7 +4,6 @@ const { signIn, logout } = require('../controllers/authController');
 
 const router = Router();
 
-// Authentication endpoints.
 router.post('/signin', asyncHandler(signIn));
 router.post('/logout', logout);
 

--- a/backend/src/routes/doctorRoutes.js
+++ b/backend/src/routes/doctorRoutes.js
@@ -21,7 +21,6 @@ const {
 
 const router = Router();
 
-// Doctor catalog endpoints.
 router.get('/', asyncHandler(getDoctors));
 router.post(
   '/apply',

--- a/backend/src/routes/patientRoutes.js
+++ b/backend/src/routes/patientRoutes.js
@@ -17,7 +17,6 @@ const {
 
 const router = Router();
 
-// Patient onboarding and data endpoints.
 router.post('/register', upload.array('medicalRecords', 6), asyncHandler(registerPatient));
 router.get('/', authenticateToken, authorizeRoles('admin'), asyncHandler(getPatients));
 router.get(

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,20 +2,16 @@ const { app, config } = require('./app');
 const database = require('./config/database');
 const { ensureSchema } = require('./database/schema');
 
-// Bootstraps the application by ensuring the database schema is present
-// before binding the HTTP server.
 async function bootstrap() {
   await database.waitForAvailability();
   await ensureSchema();
 
   app.listen(config.port, () => {
-    // eslint-disable-next-line no-console
     console.log(`Server running at http://localhost:${config.port}`);
   });
 }
 
 bootstrap().catch((error) => {
-  // eslint-disable-next-line no-console
   console.error('Failed to start server:', error);
   process.exit(1);
 });

--- a/backend/src/services/appointmentService.js
+++ b/backend/src/services/appointmentService.js
@@ -1,6 +1,4 @@
 const { execute, transaction } = require('../database/query');
-
-// Retrieves upcoming appointments for a patient.
 async function getUpcomingAppointments(patientId) {
   return execute(
     `SELECT
@@ -19,8 +17,6 @@ async function getUpcomingAppointments(patientId) {
     [patientId]
   );
 }
-
-// Retrieves historical appointments for a patient.
 async function getAppointmentHistory(patientId) {
   return execute(
     `SELECT
@@ -38,8 +34,6 @@ async function getAppointmentHistory(patientId) {
     [patientId]
   );
 }
-
-// Retrieves upcoming appointments for a doctor including patient details.
 async function getUpcomingAppointmentsForDoctor(doctorId) {
   return execute(
     `SELECT
@@ -58,8 +52,6 @@ async function getUpcomingAppointmentsForDoctor(doctorId) {
     [doctorId]
   );
 }
-
-// Lists available appointment slots for a specific doctor.
 async function getAvailableTimes(doctorId) {
   return execute(
     `SELECT
@@ -74,8 +66,6 @@ async function getAvailableTimes(doctorId) {
     [doctorId]
   );
 }
-
-// Books an appointment within a database transaction to avoid double booking.
 async function bookAppointment({ patientId, availableTimeId, notes = '' }) {
   return transaction(async (connection) => {
     const [timeSlots] = await connection.execute(

--- a/backend/src/services/doctorService.js
+++ b/backend/src/services/doctorService.js
@@ -1,7 +1,5 @@
 const bcrypt = require('bcryptjs');
 const { execute, transaction } = require('../database/query');
-
-// Retrieves all doctors from the database with their next available appointment slot.
 async function listDoctors() {
   return execute(
     `SELECT
@@ -43,14 +41,10 @@ async function listDoctors() {
       ORDER BY d.FullName ASC`
   );
 }
-
-// Finds a doctor by identifier.
 async function getDoctorById(doctorId) {
   const doctors = await execute('SELECT * FROM doctors WHERE DoctorID = ?', [doctorId]);
   return doctors[0];
 }
-
-// Increments the active patient count for a doctor.
 async function incrementDoctorPatientCount(doctorId) {
   await execute('UPDATE doctors SET CurrentPatientNumber = CurrentPatientNumber + 1 WHERE DoctorID = ?', [doctorId]);
 }

--- a/backend/src/services/patientService.js
+++ b/backend/src/services/patientService.js
@@ -1,7 +1,5 @@
 const bcrypt = require('bcryptjs');
 const { execute, transaction } = require('../database/query');
-
-// Persists a new patient with a securely hashed password.
 async function createPatient({
   fullName,
   birthDate,
@@ -46,16 +44,12 @@ async function createPatient({
     return { id: patientId, userId: userResult.insertId, fullName, email };
   });
 }
-
-// Returns the full list of patients.
 async function listPatients() {
   return execute(
     `SELECT PatientID, FullName, BirthDate, PhoneNumber, Email, Gender, Address, DoctorID, NidNumber, AvatarUrl
      FROM patients`
   );
 }
-
-// Retrieves a patient by identifier.
 async function findPatientById(id) {
   const patients = await execute(
     `SELECT PatientID, FullName, BirthDate, PhoneNumber, Email, Gender, Address, DoctorID, NidNumber, AvatarUrl
@@ -64,8 +58,6 @@ async function findPatientById(id) {
   );
   return patients[0];
 }
-
-// Returns the doctor assigned to a patient, if any.
 async function getDoctorIdForPatient(patientId) {
   const patients = await execute('SELECT DoctorID FROM patients WHERE PatientID = ?', [patientId]);
   return patients[0]?.DoctorID;

--- a/backend/src/utils/asyncHandler.js
+++ b/backend/src/utils/asyncHandler.js
@@ -1,4 +1,3 @@
-// Wraps async route handlers and forwards errors to Express.
 function asyncHandler(handler) {
   return (req, res, next) => {
     Promise.resolve(handler(req, res, next)).catch(next);

--- a/frontend/src/app/App.jsx
+++ b/frontend/src/app/App.jsx
@@ -17,6 +17,7 @@ import { SiteSettingsProvider } from '../shared/context/SiteSettingsContext';
 import DoctorApplicationPage from '../features/staff/pages/DoctorApplicationPage';
 import SupportButtons from '../shared/components/SupportButtons';
 import MedicalHistoryPage from '../features/patient/pages/MedicalHistoryPage';
+import SpecialistsPage from '../features/specialists/pages/SpecialistsPage';
 
 function App() {
   const { auth } = useContext(AuthContext);
@@ -47,6 +48,7 @@ function App() {
               <Route path="/register" element={guardPublicPage(<RegisterPage />)} />
               <Route path="/about-us" element={guardPublicPage(<AboutUs />)} />
               <Route path="/services" element={guardPublicPage(<ServicesPage />)} />
+              <Route path="/specialists" element={guardPublicPage(<SpecialistsPage />)} />
               <Route path="/reports" element={guardPublicPage(<ReportsPage />)} />
               <Route path="/apply-as-doctor" element={guardPublicPage(<DoctorApplicationPage />)} />
               <Route

--- a/frontend/src/features/admin/components/DoctorApplicationsTab.jsx
+++ b/frontend/src/features/admin/components/DoctorApplicationsTab.jsx
@@ -55,15 +55,11 @@ function DoctorApplicationsTab({ token }) {
   );
 
   useEffect(() => {
-    if (status === 'idle' && token) {
-      fetchApplications(normalizedFilter);
+    if (!token) {
+      return;
     }
-  }, [fetchApplications, normalizedFilter, status, token]);
 
-  useEffect(() => {
-    if (status !== 'idle' && token) {
-      fetchApplications(normalizedFilter);
-    }
+    fetchApplications(normalizedFilter);
   }, [fetchApplications, normalizedFilter, token]);
 
   const handleReview = async (applicationId, nextStatus) => {

--- a/frontend/src/features/auth/context/AuthContext.jsx
+++ b/frontend/src/features/auth/context/AuthContext.jsx
@@ -1,9 +1,6 @@
-// /frontend/src/AuthContext.js
-
 import React, { createContext, useState, useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 
-// Create the context
 export const AuthContext = createContext();
 
 const normalizeUser = (user) => {
@@ -24,23 +21,19 @@ const normalizeUser = (user) => {
   };
 };
 
-// Create a provider component
 export const AuthProvider = ({ children }) => {
   const [auth, setAuth] = useState({
     token: null,
     user: null,
   });
 
-  // On component mount, check for token in localStorage
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (token) {
       try {
-        const decoded = jwtDecode(token); // Updated usage
-        // Optional: Check if token is expired
+        const decoded = jwtDecode(token);
         const currentTime = Date.now() / 1000;
         if (decoded.exp < currentTime) {
-          // Token expired
           localStorage.removeItem('token');
         } else {
           setAuth({
@@ -62,7 +55,6 @@ export const AuthProvider = ({ children }) => {
     }
   }, []);
 
-  // Function to handle login
   const login = (token, user) => {
     localStorage.setItem('token', token);
     setAuth({
@@ -71,7 +63,6 @@ export const AuthProvider = ({ children }) => {
     });
   };
 
-  // Function to handle logout
   const logout = () => {
     localStorage.removeItem('token');
     setAuth({

--- a/frontend/src/features/home/pages/HomePage.jsx
+++ b/frontend/src/features/home/pages/HomePage.jsx
@@ -103,9 +103,14 @@ function HomePage() {
 
   const heroBackgroundStyle = heroContent.imageUrl
     ? {
-        backgroundImage: `linear-gradient(135deg, rgba(7, 116, 105, 0.82), rgba(15, 23, 42, 0.78)), url(${heroContent.imageUrl})`,
+        backgroundImage: `url(${heroContent.imageUrl})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
       }
     : {};
+  const heroOverlayStyle = {
+    background: 'linear-gradient(135deg, rgba(7, 116, 105, 0.35), rgba(15, 23, 42, 0.6))',
+  };
 
   return (
     <div className="mx-auto w-full max-w-6xl px-4 pb-20 sm:px-6 lg:px-8">
@@ -113,7 +118,7 @@ function HomePage() {
         className="relative mt-6 overflow-hidden rounded-[40px] border border-white/30 bg-slate-900 text-white shadow-glass"
         style={heroBackgroundStyle}
       >
-        <div className="absolute inset-0 bg-cover bg-center" aria-hidden="true" style={heroBackgroundStyle} />
+        <div className="absolute inset-0" aria-hidden="true" style={heroOverlayStyle} />
         <div className="relative z-10 flex flex-col gap-8 p-10 md:flex-row md:items-center md:justify-between">
           <div className="max-w-2xl space-y-5">
             <span className="inline-flex items-center rounded-full bg-white/15 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-white/80">
@@ -131,10 +136,10 @@ function HomePage() {
                 {heroContent.ctaLabel}
               </Link>
               <Link
-                to="/services"
+                to="/specialists"
                 className="inline-flex items-center justify-center rounded-full border border-white/70 px-6 py-3 text-base font-semibold text-white transition hover:bg-white/10"
               >
-                Explore services
+                Meet our specialists
               </Link>
             </div>
             {heroStatus === 'failed' ? (

--- a/frontend/src/features/patient/pages/PatientProfile.jsx
+++ b/frontend/src/features/patient/pages/PatientProfile.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AuthContext } from '../../auth/context/AuthContext';
 import { FaCalendarCheck } from 'react-icons/fa';
@@ -20,7 +20,7 @@ function PatientProfile() {
   const [searchTerm, setSearchTerm] = useState('');
   const [sortOrder, setSortOrder] = useState('desc');
 
-  const fetchProfileAndTimeline = async () => {
+  const fetchProfileAndTimeline = useCallback(async () => {
     if (!patientId || !auth.token) {
       return;
     }
@@ -69,7 +69,7 @@ function PatientProfile() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiBaseUrl, auth.token, patientId]);
 
   const refreshTimeline = async () => {
     try {
@@ -90,8 +90,7 @@ function PatientProfile() {
 
   useEffect(() => {
     fetchProfileAndTimeline();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [patientId]);
+  }, [fetchProfileAndTimeline]);
 
   const appointmentEntries = useMemo(() => {
     const normalizedSearch = searchTerm.trim().toLowerCase();

--- a/frontend/src/features/specialists/pages/SpecialistsPage.jsx
+++ b/frontend/src/features/specialists/pages/SpecialistsPage.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { FiHeart, FiActivity, FiCpu } from 'react-icons/fi';
+import { MdOutlineBiotech, MdOutlinePsychology } from 'react-icons/md';
+import { GiKidneys, GiLungs } from 'react-icons/gi';
+
+const specialistCatalog = [
+  {
+    name: 'Cardiology',
+    description: 'Advanced cardiac diagnostics, minimally invasive procedures, and long-term heart health programs.',
+    icon: FiHeart,
+    accentClass: 'bg-rose-100 text-rose-500',
+  },
+  {
+    name: 'Orthopedics',
+    description: 'Joint preservation, robotic-assisted surgeries, and personalized rehabilitation for active recovery.',
+    icon: FiActivity,
+    accentClass: 'bg-orange-100 text-orange-500',
+  },
+  {
+    name: 'Neurology',
+    description: 'Comprehensive stroke care, neurosurgery coordination, and ongoing neurological wellness support.',
+    icon: FiCpu,
+    accentClass: 'bg-indigo-100 text-indigo-500',
+  },
+  {
+    name: 'Gastroenterology',
+    description: 'Digestive health screenings, endoscopic therapies, and nutrition-guided treatment pathways.',
+    icon: MdOutlineBiotech,
+    accentClass: 'bg-emerald-100 text-emerald-600',
+  },
+  {
+    name: 'Oncology',
+    description: 'Integrated cancer care with precision medicine, infusion therapy, and survivorship planning.',
+    icon: MdOutlinePsychology,
+    accentClass: 'bg-fuchsia-100 text-fuchsia-500',
+  },
+  {
+    name: 'Transplant Services',
+    description: 'Kidney, liver, heart, and lung transplant programs supported by dedicated post-operative teams.',
+    icon: GiKidneys,
+    accentClass: 'bg-sky-100 text-sky-500',
+  },
+  {
+    name: 'Pulmonology',
+    description: 'Respiratory diagnostics, pulmonary rehabilitation, and chronic lung disease management clinics.',
+    icon: GiLungs,
+    accentClass: 'bg-cyan-100 text-cyan-500',
+  },
+];
+
+function SpecialistsPage() {
+  return (
+    <div className="mx-auto w-full max-w-6xl space-y-12">
+      <section className="mt-6 rounded-[36px] border border-brand-primary/30 bg-white/80 p-10 shadow-glass backdrop-blur">
+        <div className="max-w-3xl space-y-4">
+          <p className="inline-flex items-center rounded-full bg-brand-secondary px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand-dark">
+            Specialist care
+          </p>
+          <h1 className="text-4xl font-semibold leading-tight text-brand-dark sm:text-5xl">
+            Experts across every critical discipline, ready to collaborate on your care plan
+          </h1>
+          <p className="text-lg text-slate-600">
+            Our specialists combine advanced technology with compassionate care. Browse the departments below to discover how each team supports patients with comprehensive treatment pathways.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+        {specialistCatalog.map(({ name, description, icon: Icon, accentClass }) => (
+          <article
+            key={name}
+            className="group flex h-full flex-col justify-between rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-card transition hover:-translate-y-1 hover:border-brand-primary/60 hover:shadow-glass"
+          >
+            <div className="flex items-start gap-4">
+              <span className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${accentClass}`}>
+                <Icon className="text-2xl" />
+              </span>
+              <div className="space-y-2">
+                <h2 className="text-xl font-semibold text-slate-800">{name}</h2>
+                <p className="text-sm leading-relaxed text-slate-600">{description}</p>
+              </div>
+            </div>
+            <div className="mt-6 flex items-center gap-2 text-sm font-semibold text-brand-primary opacity-0 transition group-hover:opacity-100">
+              <span>View care team</span>
+              <svg
+                className="h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M5 12h14M13 6l6 6-6 6"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+
+export default SpecialistsPage;

--- a/frontend/src/features/staff/components/DoctorReportCenter.jsx
+++ b/frontend/src/features/staff/components/DoctorReportCenter.jsx
@@ -12,30 +12,38 @@ function DoctorReportCenter({
   feedback,
 }) {
   const [searchParams, setSearchParams] = useSearchParams();
+  const appointmentIdFromQuery = searchParams.get('appointmentId');
+  const searchParamsSnapshot = searchParams.toString();
 
   useEffect(() => {
-    const requestedId = searchParams.get('appointmentId');
-    if (requestedId) {
-      const parsedId = Number.parseInt(requestedId, 10);
-      if (!Number.isNaN(parsedId) && parsedId !== reportForm.appointmentId) {
-        const appointmentExists = appointments.some((appt) => appt.AppointmentID === parsedId);
-        if (appointmentExists) {
-          onSelectAppointment(parsedId);
-        }
-      }
-      const updatedParams = new URLSearchParams(searchParams);
-      updatedParams.delete('appointmentId');
-      setSearchParams(updatedParams, { replace: true });
+    if (!appointmentIdFromQuery) {
+      return;
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appointments]);
+
+    const parsedId = Number.parseInt(appointmentIdFromQuery, 10);
+    if (!Number.isNaN(parsedId) && parsedId !== reportForm.appointmentId) {
+      const appointmentExists = appointments.some((appt) => appt.AppointmentID === parsedId);
+      if (appointmentExists) {
+        onSelectAppointment(parsedId);
+      }
+    }
+    const updatedParams = new URLSearchParams(searchParamsSnapshot);
+    updatedParams.delete('appointmentId');
+    setSearchParams(updatedParams, { replace: true });
+  }, [
+    appointmentIdFromQuery,
+    appointments,
+    onSelectAppointment,
+    reportForm.appointmentId,
+    searchParamsSnapshot,
+    setSearchParams,
+  ]);
 
   useEffect(() => {
     if (!reportForm.appointmentId && appointments.length) {
       onSelectAppointment(appointments[0].AppointmentID);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [appointments, reportForm.appointmentId]);
+  }, [appointments, onSelectAppointment, reportForm.appointmentId]);
 
   const selectedAppointment = appointments.find(
     (appointment) => appointment.AppointmentID === reportForm.appointmentId

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -1,16 +1,14 @@
-// /frontend/src/index.js
-
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './app/App';
 import reportWebVitals from './reportWebVitals';
-import { AuthProvider } from './features/auth/context/AuthContext'; // Import AuthProvider
+import { AuthProvider } from './features/auth/context/AuthContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <AuthProvider> {/* Wrap App with AuthProvider */}
+    <AuthProvider>
       <App />
     </AuthProvider>
   </React.StrictMode>

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -1,5 +1,1 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';

--- a/frontend/src/shared/components/Header.jsx
+++ b/frontend/src/shared/components/Header.jsx
@@ -43,6 +43,7 @@ function Header() {
         return [
           { label: 'Home', to: '/' },
           { label: 'Book', to: '/book-appointment' },
+          { label: 'Specialists', to: '/specialists' },
           { label: 'Services', to: '/services' },
           { label: 'Get Reports', to: '/reports' },
           { label: 'About Us', to: '/about-us' },
@@ -55,12 +56,13 @@ function Header() {
         return [
           { label: 'Home', to: '/' },
           { label: 'Book', to: '/book-appointment' },
+          { label: 'Specialists', to: '/specialists' },
           { label: 'Get Reports', to: '/reports' },
           { label: 'Services', to: '/services' },
           { label: 'About Us', to: '/about-us' },
         ];
     }
-  }, [auth.user?.role]);
+  }, [auth.user?.role, dashboardLink.path]);
 
   const toggleMobileMenu = () => {
     setMobileMenuOpen((prev) => !prev);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,3 @@
-/** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
   theme: {


### PR DESCRIPTION
## Summary
- remove inline comments throughout the backend and frontend and replace eslint suppressions with stable hook dependencies
- lighten the homepage hero overlay and update the secondary CTA to highlight the specialist catalog
- add a specialists page with icon cards and expose it via routing and navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e4110a3f9483228101b4c878751c9c