### PR TITLE
Add payments and weekly scheduling for doctor appointments

### DIFF
--- a/backend/createtable.sql
+++ b/backend/createtable.sql
@@ -7,7 +7,12 @@ CREATE TABLE IF NOT EXISTS doctors (
     DoctorID INT AUTO_INCREMENT PRIMARY KEY,
     FullName VARCHAR(255) NOT NULL,
     MaxPatientNumber INT NOT NULL,
-    CurrentPatientNumber INT NOT NULL DEFAULT 0
+    CurrentPatientNumber INT NOT NULL DEFAULT 0,
+    Email VARCHAR(255) NULL,
+    PhoneNumber VARCHAR(50) NULL,
+    Specialization VARCHAR(255) NULL,
+    AvatarUrl TEXT NULL,
+    ConsultationFee DECIMAL(10,2) NOT NULL DEFAULT 0
 ) ENGINE=InnoDB;
 
 -- ---------------------------
@@ -69,6 +74,7 @@ CREATE TABLE IF NOT EXISTS available_time (
     StartTime TIME NOT NULL,
     EndTime TIME NOT NULL,
     IsAvailable TINYINT(1) NOT NULL DEFAULT 1,
+    DayOfWeek TINYINT NOT NULL DEFAULT 0,
     FOREIGN KEY (DoctorID) REFERENCES doctors(DoctorID)
         ON UPDATE CASCADE
         ON DELETE CASCADE
@@ -94,7 +100,24 @@ CREATE TABLE IF NOT EXISTS appointments (
 ) ENGINE=InnoDB;
 
 -- ---------------------------
--- 7. Create the site_content table
+-- 7. Create the payments table
+-- ---------------------------
+CREATE TABLE IF NOT EXISTS payments (
+    PaymentID INT AUTO_INCREMENT PRIMARY KEY,
+    AppointmentID INT NOT NULL,
+    Amount DECIMAL(10,2) NOT NULL,
+    Currency VARCHAR(10) NOT NULL DEFAULT 'BDT',
+    Method ENUM('bkash', 'nagad', 'card') NOT NULL,
+    Status ENUM('paid', 'refunded', 'failed') NOT NULL DEFAULT 'paid',
+    TransactionReference VARCHAR(191) NULL,
+    PaidAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (AppointmentID) REFERENCES appointments(AppointmentID)
+        ON UPDATE CASCADE
+        ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+-- ---------------------------
+-- 8. Create the site_content table
 -- ---------------------------
 CREATE TABLE IF NOT EXISTS site_content (
     ContentKey VARCHAR(100) PRIMARY KEY,
@@ -103,7 +126,7 @@ CREATE TABLE IF NOT EXISTS site_content (
 ) ENGINE=InnoDB;
 
 -- ---------------------------
--- 8. Create the service_packages table
+-- 9. Create the service_packages table
 -- ---------------------------
 CREATE TABLE IF NOT EXISTS service_packages (
     PackageID INT AUTO_INCREMENT PRIMARY KEY,
@@ -117,7 +140,7 @@ CREATE TABLE IF NOT EXISTS service_packages (
 ) ENGINE=InnoDB;
 
 -- ---------------------------
--- 9. Create the service_package_items table
+-- 10. Create the service_package_items table
 -- ---------------------------
 CREATE TABLE IF NOT EXISTS service_package_items (
     PackageItemID INT AUTO_INCREMENT PRIMARY KEY,
@@ -133,7 +156,7 @@ CREATE TABLE IF NOT EXISTS service_package_items (
 ) ENGINE=InnoDB;
 
 -- ---------------------------
--- 10. Create Indexes for Performance
+-- 11. Create Indexes for Performance
 -- ---------------------------
 CREATE INDEX idx_patients_email ON patients(Email);
 CREATE INDEX idx_users_role ON users(Role);
@@ -142,7 +165,7 @@ CREATE INDEX idx_appointments_doctor_id ON appointments(DoctorID);
 CREATE INDEX idx_available_time_doctor_id ON available_time(DoctorID);
 
 -- ---------------------------
--- 11. Seed baseline reference data
+-- 12. Seed baseline reference data
 -- ---------------------------
 INSERT INTO doctors (FullName, MaxPatientNumber, CurrentPatientNumber)
 SELECT 'Dr. John Smith', 100, 0 FROM dual

--- a/backend/populateAvailableTime.js
+++ b/backend/populateAvailableTime.js
@@ -51,10 +51,11 @@ async function populateAvailableTime() {
         const endTime = formatTime(hour + 1);
 
         for (const doctorID of doctorIDs) {
+          const dayOfWeek = currentDate.getDay();
           const isAvailable = Math.random() < 0.7 ? 1 : 0;
           await connection.execute(
-            'INSERT INTO available_time (DoctorID, ScheduleDate, StartTime, EndTime, IsAvailable) VALUES (?, ?, ?, ?, ?)',
-            [doctorID, formattedDate, startTime, endTime, isAvailable]
+            'INSERT INTO available_time (DoctorID, ScheduleDate, DayOfWeek, StartTime, EndTime, IsAvailable) VALUES (?, ?, ?, ?, ?, ?)',
+            [doctorID, formattedDate, dayOfWeek, startTime, endTime, isAvailable]
           );
           totalInserts += 1;
         }

--- a/backend/src/controllers/appointmentController.js
+++ b/backend/src/controllers/appointmentController.js
@@ -67,6 +67,16 @@ async function bookAppointmentHandler(req, res) {
   }
 
   const files = req.files || [];
+  const paymentPayload = {
+    method: req.body.paymentMethod,
+    reference: req.body.paymentReference,
+    amount: req.body.paymentAmount,
+    currency: req.body.paymentCurrency,
+  };
+
+  if (!paymentPayload.method || !paymentPayload.amount) {
+    return res.status(400).json({ error: 'Payment method and amount are required to book an appointment.' });
+  }
 
   if (req.user) {
     if (req.user.role !== 'patient') {
@@ -77,6 +87,7 @@ async function bookAppointmentHandler(req, res) {
       patientId: req.user.id,
       availableTimeId: slotId,
       notes,
+      payment: paymentPayload,
     });
 
     await persistDocuments(req.user.id, appointment.appointmentId, files);
@@ -92,6 +103,7 @@ async function bookAppointmentHandler(req, res) {
         Status: 'pending',
         Notes: appointment.notes,
       },
+      payment: appointment.payment,
     });
   }
 
@@ -119,6 +131,7 @@ async function bookAppointmentHandler(req, res) {
     patientId: patient.id,
     availableTimeId: slotId,
     notes,
+    payment: paymentPayload,
   });
 
   await persistDocuments(patient.id, appointment.appointmentId, files);
@@ -153,6 +166,7 @@ async function bookAppointmentHandler(req, res) {
       Status: 'pending',
       Notes: appointment.notes,
     },
+    payment: appointment.payment,
   });
 }
 

--- a/backend/src/controllers/doctorController.js
+++ b/backend/src/controllers/doctorController.js
@@ -255,7 +255,7 @@ async function updateDoctorProfileHandler(req, res) {
     return res.status(403).json({ message: 'Access denied.' });
   }
 
-  const { fullName, email, phoneNumber, specialization } = req.body;
+  const { fullName, email, phoneNumber, specialization, consultationFee } = req.body;
 
   if (!fullName || !email || !phoneNumber) {
     return res.status(400).json({ message: 'Full name, email, and phone number are required.' });
@@ -275,6 +275,7 @@ async function updateDoctorProfileHandler(req, res) {
     phoneNumber,
     specialization,
     avatarUrl,
+    consultationFee: consultationFee ?? doctor.ConsultationFee,
   });
 
   return res.json({ message: 'Profile updated successfully.', avatarUrl });

--- a/frontend/src/features/patient/pages/PatientProfile.jsx
+++ b/frontend/src/features/patient/pages/PatientProfile.jsx
@@ -120,6 +120,12 @@ function PatientProfile() {
         dateValue: entryDate,
         displayDate,
         timeRange,
+        payment: {
+          amount: appointment.PaymentAmount,
+          status: appointment.PaymentStatus || 'paid',
+          method: appointment.PaymentMethod || '',
+          reference: appointment.PaymentReference || '',
+        },
       };
     });
 
@@ -622,6 +628,37 @@ function PatientProfile() {
                       {entry.timeRange ? ` · ${entry.timeRange}` : ''}
                     </p>
                     {entry.notes ? <p className="mt-2 text-xs text-slate-600">{entry.notes}</p> : null}
+                    {(() => {
+                      if (!entry.payment) {
+                        return null;
+                      }
+                      const amountValue =
+                        typeof entry.payment.amount === 'number' ||
+                        (typeof entry.payment.amount === 'string' && entry.payment.amount !== '')
+                          ? Number(entry.payment.amount).toLocaleString('en-US', {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })
+                          : null;
+                      const methodLabel = entry.payment.method
+                        ? `${entry.payment.method.charAt(0).toUpperCase()}${entry.payment.method.slice(1)}`
+                        : 'Not recorded';
+                      const status = entry.payment.status || 'paid';
+                      const statusColor =
+                        status === 'paid'
+                          ? 'text-emerald-600'
+                          : status === 'refunded'
+                          ? 'text-slate-500'
+                          : 'text-amber-600';
+
+                      return (
+                        <p className={`mt-2 text-xs ${statusColor}`}>
+                          {status === 'paid' ? 'Paid' : status === 'refunded' ? 'Refunded' : 'Payment pending'}
+                          {amountValue ? ` · BDT ${amountValue}` : ''} via {methodLabel}
+                          {entry.payment.reference ? ` • Ref: ${entry.payment.reference}` : ''}
+                        </p>
+                      );
+                    })()}
                   </div>
                 </div>
               </article>

--- a/frontend/src/features/staff/components/DoctorAppointmentsOverview.jsx
+++ b/frontend/src/features/staff/components/DoctorAppointmentsOverview.jsx
@@ -69,6 +69,26 @@ function DoctorAppointmentsOverview({
             const patientDocuments = Array.isArray(appointment.PatientDocuments)
               ? appointment.PatientDocuments
               : [];
+            const paymentAmount = appointment.PaymentAmount;
+            const paymentStatus = appointment.PaymentStatus || 'paid';
+            const paymentMethod = appointment.PaymentMethod || '';
+            const paymentReference = appointment.PaymentReference || '';
+            const paymentStatusClass =
+              paymentStatus === 'paid'
+                ? 'bg-emerald-100 text-emerald-700'
+                : paymentStatus === 'refunded'
+                ? 'bg-slate-200 text-slate-600'
+                : 'bg-amber-100 text-amber-700';
+            const paymentAmountLabel =
+              typeof paymentAmount === 'number' || (typeof paymentAmount === 'string' && paymentAmount !== '')
+                ? Number(paymentAmount).toLocaleString('en-US', {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })
+                : null;
+            const paymentMethodLabel = paymentMethod
+              ? `${paymentMethod.charAt(0).toUpperCase()}${paymentMethod.slice(1)}`
+              : 'Not recorded';
 
             const viewHistory = () => {
               if (onViewPatientHistory) {
@@ -117,9 +137,23 @@ function DoctorAppointmentsOverview({
                           </li>
                         ))}
                       </ul>
-                    ) : (
-                      <p className="mt-2 text-xs text-slate-400">No medical reports uploaded for this appointment.</p>
-                    )}
+                  ) : (
+                    <p className="mt-2 text-xs text-slate-400">No medical reports uploaded for this appointment.</p>
+                  )}
+                </div>
+                  <div className="rounded-2xl border border-emerald-100 bg-emerald-50 px-3 py-2">
+                    <p className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-emerald-700">
+                      Payment
+                      <span className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${paymentStatusClass}`}>
+                        {paymentStatus.toUpperCase()}
+                      </span>
+                    </p>
+                    <p className="mt-2 text-xs text-emerald-700">
+                      {paymentAmountLabel ? `BDT ${paymentAmountLabel}` : 'Amount pending'} • {paymentMethodLabel}
+                    </p>
+                    {paymentReference ? (
+                      <p className="text-[11px] text-emerald-600">Ref: {paymentReference}</p>
+                    ) : null}
                   </div>
                 </div>
                 <div className="flex flex-col gap-3 text-xs sm:flex-row sm:items-center">

--- a/frontend/src/features/staff/components/DoctorAvailabilityPlanner.jsx
+++ b/frontend/src/features/staff/components/DoctorAvailabilityPlanner.jsx
@@ -10,9 +10,6 @@ function DoctorAvailabilityPlanner({
   onClearDays,
   onPlannerFieldChange,
   onCustomTimeToggle,
-  onCustomDateChange,
-  onAddCustomDate,
-  onRemoveCustomDate,
   onSubmit,
   startTimeOptions,
   endTimeOptions,
@@ -23,7 +20,7 @@ function DoctorAvailabilityPlanner({
         <div>
           <h2 className="text-xl font-semibold text-brand-primary">Plan your availability</h2>
           <p className="mt-1 text-xs text-slate-500">
-            Select weekly days or custom dates, then choose the hours you are available for appointments.
+            Select the days you are available each week and we&apos;ll automatically schedule the upcoming weeks for you.
           </p>
         </div>
       </div>
@@ -76,52 +73,33 @@ function DoctorAvailabilityPlanner({
           </div>
         </div>
 
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Custom dates</p>
-          <div className="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
-            <input
-              type="date"
-              value={planner.customDateInput}
-              onChange={onCustomDateChange}
-              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-accent sm:max-w-xs"
-            />
-            <button
-              type="button"
-              onClick={onAddCustomDate}
-              className="inline-flex items-center justify-center rounded-full border border-brand-primary px-4 py-2 text-xs font-semibold text-brand-primary transition hover:bg-brand-primary hover:text-white"
-            >
-              Add date
-            </button>
+        <div className="grid gap-3 sm:grid-cols-2 sm:items-end">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Planning horizon</p>
+            <p className="mt-1 text-xs text-slate-400">
+              We&apos;ll duplicate your selected weekdays for the upcoming weeks so patients can book recurring slots.
+            </p>
           </div>
-          {planner.customDates.length ? (
-            <ul className="mt-3 flex flex-wrap gap-2 text-xs text-slate-600">
-              {planner.customDates.map((date) => (
-                <li
-                  key={date}
-                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1"
-                >
-                  <span>
-                    {new Date(`${date}T00:00`).toLocaleDateString('en-US', {
-                      weekday: 'short',
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => onRemoveCustomDate(date)}
-                    className="text-slate-400 transition hover:text-rose-500"
-                    aria-label={`Remove ${date}`}
-                  >
-                    &times;
-                  </button>
-                </li>
+          <label className="flex flex-col text-xs font-semibold text-slate-600">
+            Generate availability for
+            <select
+              name="weeksToGenerate"
+              value={planner.weeksToGenerate}
+              onChange={onPlannerFieldChange}
+              className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-accent"
+            >
+              {[1, 2, 3, 4, 5, 6].map((weeks) => (
+                <option key={weeks} value={weeks}>
+                  {weeks} week{weeks === 1 ? '' : 's'} ahead
+                </option>
               ))}
-            </ul>
-          ) : (
-            <p className="mt-2 text-xs text-slate-400">Optional: select specific dates outside your weekly routine.</p>
-          )}
+            </select>
+          </label>
         </div>
+        <p className="text-xs text-slate-500">
+          New slots will be added for the next {planner.weeksToGenerate}{' '}
+          week{planner.weeksToGenerate === 1 ? '' : 's'} on the selected days.
+        </p>
 
         <div className="grid gap-4 sm:grid-cols-2">
           <label className="flex flex-col text-xs font-semibold text-slate-600">
@@ -214,13 +192,12 @@ DoctorAvailabilityPlanner.propTypes = {
   ).isRequired,
   planner: PropTypes.shape({
     selectedDays: PropTypes.arrayOf(PropTypes.number).isRequired,
-    customDates: PropTypes.arrayOf(PropTypes.string).isRequired,
-    customDateInput: PropTypes.string.isRequired,
     startTime: PropTypes.string.isRequired,
     endTime: PropTypes.string.isRequired,
     useCustomTime: PropTypes.bool.isRequired,
     customStartTime: PropTypes.string,
     customEndTime: PropTypes.string,
+    weeksToGenerate: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   }).isRequired,
   availabilityFeedback: PropTypes.shape({
     type: PropTypes.oneOf(['success', 'error']).isRequired,
@@ -231,9 +208,6 @@ DoctorAvailabilityPlanner.propTypes = {
   onClearDays: PropTypes.func.isRequired,
   onPlannerFieldChange: PropTypes.func.isRequired,
   onCustomTimeToggle: PropTypes.func.isRequired,
-  onCustomDateChange: PropTypes.func.isRequired,
-  onAddCustomDate: PropTypes.func.isRequired,
-  onRemoveCustomDate: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   startTimeOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
   endTimeOptions: PropTypes.arrayOf(PropTypes.string).isRequired,

--- a/frontend/src/features/staff/components/DoctorProfileSettings.jsx
+++ b/frontend/src/features/staff/components/DoctorProfileSettings.jsx
@@ -70,6 +70,22 @@ function DoctorProfileSettings({
           />
         </label>
         <label className="flex flex-col text-xs font-semibold text-slate-600">
+          Consultation fee (BDT)
+          <input
+            type="number"
+            name="consultationFee"
+            min="0"
+            step="0.01"
+            value={profileForm.consultationFee}
+            onChange={onProfileChange}
+            required
+            className="mt-1 rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-accent"
+          />
+          <span className="mt-1 text-[11px] font-normal text-slate-400">
+            Patients will pay this amount when booking an appointment with you.
+          </span>
+        </label>
+        <label className="flex flex-col text-xs font-semibold text-slate-600">
           Profile photo
           <input
             type="file"
@@ -129,6 +145,7 @@ DoctorProfileSettings.propTypes = {
     phoneNumber: PropTypes.string.isRequired,
     specialization: PropTypes.string,
     avatarUrl: PropTypes.string,
+    consultationFee: PropTypes.string.isRequired,
   }).isRequired,
   onProfileChange: PropTypes.func.isRequired,
   onProfileSubmit: PropTypes.func.isRequired,


### PR DESCRIPTION
## Summary
- add consultation fee and weekly availability defaults in the schema and doctor services
- require payment details when booking and persist payment records with appointments
- update patient and staff dashboards plus booking flows to surface fees, payment info, and weekly availability planning

## Testing
- CI=true npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_b_68e4b5a411f083229e009d35d5911754