### PR TITLE
Add missing CreatedAt column for doctors table

### DIFF
--- a/backend/createtable.sql
+++ b/backend/createtable.sql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS doctors (
     PhoneNumber VARCHAR(50) NULL,
     Specialization VARCHAR(255) NULL,
     AvatarUrl TEXT NULL,
-    ConsultationFee DECIMAL(10,2) NOT NULL DEFAULT 0
+    ConsultationFee DECIMAL(10,2) NOT NULL DEFAULT 0,
+    CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
 -- ---------------------------

--- a/backend/src/database/schema.js
+++ b/backend/src/database/schema.js
@@ -98,7 +98,8 @@ async function createDoctorsTable() {
       PhoneNumber VARCHAR(50) NULL,
       Specialization VARCHAR(255) NULL,
       AvatarUrl TEXT NULL,
-      ConsultationFee DECIMAL(10, 2) NOT NULL DEFAULT 0
+      ConsultationFee DECIMAL(10, 2) NOT NULL DEFAULT 0,
+      CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
     )`
   );
 
@@ -107,6 +108,7 @@ async function createDoctorsTable() {
   await addColumnIfMissing('doctors', 'Specialization', 'VARCHAR(255) NULL');
   await addColumnIfMissing('doctors', 'AvatarUrl', 'TEXT NULL');
   await addColumnIfMissing('doctors', 'ConsultationFee', 'DECIMAL(10, 2) NOT NULL DEFAULT 0');
+  await addColumnIfMissing('doctors', 'CreatedAt', 'DATETIME DEFAULT CURRENT_TIMESTAMP');
 }
 
 async function createPatientsTable() {


### PR DESCRIPTION
## Summary
- add the CreatedAt column to the runtime schema initialization for doctors
- update the SQL bootstrap script so new databases also include the CreatedAt timestamp

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e4c8c13d888322a168ef78bd9e7446