### PR TITLE
chore: remove comments and improve backend shutdown handling

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,10 @@
-# Use an official Node.js runtime as the base image
 FROM node:20-alpine AS base
 
 WORKDIR /app
 
-# Install production dependencies based on the lockfile for reproducible builds
 COPY package*.json ./
 RUN npm ci --omit=dev
 
-# Copy the application source
 COPY src ./src
 COPY populateAvailableTime.js ./
 COPY createtable.sql ./
@@ -16,5 +13,4 @@ ENV NODE_ENV=production
 
 EXPOSE 5001
 
-# Start the API server
 CMD ["node", "src/server.js"]

--- a/backend/createtable.sql
+++ b/backend/createtable.sql
@@ -1,8 +1,4 @@
--- MySQL schema and seed script for Destination Health
 
--- ---------------------------
--- 1. Create the doctors table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS doctors (
     DoctorID INT AUTO_INCREMENT PRIMARY KEY,
     FullName VARCHAR(255) NOT NULL,
@@ -16,9 +12,6 @@ CREATE TABLE IF NOT EXISTS doctors (
     CreatedAt DATETIME DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 2. Create the patients table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS patients (
     PatientID INT AUTO_INCREMENT PRIMARY KEY,
     FullName VARCHAR(255) NOT NULL,
@@ -34,17 +27,11 @@ CREATE TABLE IF NOT EXISTS patients (
         ON DELETE SET NULL
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 3. Create the admins table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS admins (
     AdminID INT AUTO_INCREMENT PRIMARY KEY,
     FullName VARCHAR(255) NOT NULL
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 4. Create the users table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS users (
     UserID INT AUTO_INCREMENT PRIMARY KEY,
     Email VARCHAR(255) NOT NULL UNIQUE,
@@ -65,9 +52,6 @@ CREATE TABLE IF NOT EXISTS users (
     )
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 5. Create the available_time table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS available_time (
     AvailableTimeID INT AUTO_INCREMENT PRIMARY KEY,
     DoctorID INT NOT NULL,
@@ -81,9 +65,6 @@ CREATE TABLE IF NOT EXISTS available_time (
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 6. Create the appointments table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS appointments (
     AppointmentID INT AUTO_INCREMENT PRIMARY KEY,
     PatientID INT NOT NULL,
@@ -100,9 +81,6 @@ CREATE TABLE IF NOT EXISTS appointments (
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 7. Create the payments table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS payments (
     PaymentID INT AUTO_INCREMENT PRIMARY KEY,
     AppointmentID INT NOT NULL,
@@ -117,18 +95,12 @@ CREATE TABLE IF NOT EXISTS payments (
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 8. Create the site_content table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS site_content (
     ContentKey VARCHAR(100) PRIMARY KEY,
     ContentValue LONGTEXT NOT NULL,
     UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 9. Create the service_packages table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS service_packages (
     PackageID INT AUTO_INCREMENT PRIMARY KEY,
     PackageName VARCHAR(255) NOT NULL,
@@ -140,9 +112,6 @@ CREATE TABLE IF NOT EXISTS service_packages (
     UpdatedAt DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 10. Create the service_package_items table
--- ---------------------------
 CREATE TABLE IF NOT EXISTS service_package_items (
     PackageItemID INT AUTO_INCREMENT PRIMARY KEY,
     PackageID INT NOT NULL,
@@ -156,9 +125,6 @@ CREATE TABLE IF NOT EXISTS service_package_items (
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 10. Create the package_orders table to track lab package purchases
--- ---------------------------
 CREATE TABLE IF NOT EXISTS package_orders (
     PackageOrderID INT AUTO_INCREMENT PRIMARY KEY,
     PackageID INT NOT NULL,
@@ -178,18 +144,12 @@ CREATE TABLE IF NOT EXISTS package_orders (
         ON DELETE CASCADE
 ) ENGINE=InnoDB;
 
--- ---------------------------
--- 11. Create Indexes for Performance
--- ---------------------------
 CREATE INDEX idx_patients_email ON patients(Email);
 CREATE INDEX idx_users_role ON users(Role);
 CREATE INDEX idx_appointments_patient_id ON appointments(PatientID);
 CREATE INDEX idx_appointments_doctor_id ON appointments(DoctorID);
 CREATE INDEX idx_available_time_doctor_id ON available_time(DoctorID);
 
--- ---------------------------
--- 12. Seed baseline reference data
--- ---------------------------
 INSERT INTO doctors (FullName, MaxPatientNumber, CurrentPatientNumber)
 SELECT 'Dr. John Smith', 100, 0 FROM dual
 WHERE NOT EXISTS (SELECT 1 FROM doctors WHERE FullName = 'Dr. John Smith');
@@ -218,9 +178,6 @@ INSERT INTO admins (FullName)
 SELECT 'System Administrator' FROM dual
 WHERE NOT EXISTS (SELECT 1 FROM admins WHERE FullName = 'System Administrator');
 
--- ---------------------------
--- 12. Seed marketing content (about & service packages)
--- ---------------------------
 INSERT INTO site_content (ContentKey, ContentValue)
 SELECT 'about_page', JSON_OBJECT(
     'hero', JSON_OBJECT(
@@ -893,9 +850,6 @@ WHERE p.PackageName = 'Package-5'
     SELECT 1 FROM service_package_items spi WHERE spi.PackageID = p.PackageID AND spi.ItemName = 'Needle, Tube & Reg. Charges'
   );
 
--- ---------------------------
--- 13. Seed role-based authentication accounts
--- ---------------------------
 INSERT INTO users (Email, PasswordHash, Role, AdminID)
 SELECT 'admin@hospital.com', '$2a$10$D5s70fBDZ1.6vQrPYC0.AuBZGAPll7n/eI16oQ4GhWG0V6h78trKC', 'admin', a.AdminID
 FROM admins a
@@ -908,7 +862,6 @@ FROM doctors d
 WHERE d.FullName = 'Dr. John Smith'
   AND NOT EXISTS (SELECT 1 FROM users WHERE Email = 'dr.john@hospital.com');
 
--- Ensure each patient record has a corresponding user entry
 INSERT INTO users (Email, PasswordHash, Role, PatientID)
 SELECT p.Email, p.PasswordHash, 'patient', p.PatientID
 FROM patients p
@@ -916,9 +869,6 @@ WHERE NOT EXISTS (
     SELECT 1 FROM users u WHERE u.PatientID = p.PatientID
 );
 
--- ---------------------------
--- 14. Triggers to maintain doctor patient counts
--- ---------------------------
 DELIMITER //
 
 CREATE TRIGGER trg_after_patient_insert

--- a/backend/src/middleware/upload.js
+++ b/backend/src/middleware/upload.js
@@ -5,7 +5,7 @@ const storage = multer.memoryStorage();
 const upload = multer({
   storage,
   limits: {
-    fileSize: 10 * 1024 * 1024, // 10 MB per file
+    fileSize: 10 * 1024 * 1024,
     files: 10,
   },
 });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -2,16 +2,57 @@ const { app, config } = require('./app');
 const database = require('./config/database');
 const { ensureSchema } = require('./database/schema');
 
+let server;
+let isShuttingDown = false;
+
 async function bootstrap() {
   await database.waitForAvailability();
   await ensureSchema();
 
-  app.listen(config.port, () => {
+  server = app.listen(config.port, () => {
     console.log(`Server running at http://localhost:${config.port}`);
   });
 }
 
+async function shutdown(signal, exitCode = 0) {
+  if (isShuttingDown) {
+    return;
+  }
+  isShuttingDown = true;
+  console.log(`Received ${signal}. Commencing graceful shutdown.`);
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+  await database.end();
+  process.exit(exitCode);
+}
+
+['SIGTERM', 'SIGINT'].forEach((signal) => {
+  process.on(signal, () => {
+    shutdown(signal).catch((error) => {
+      console.error('Graceful shutdown failed:', error);
+      process.exit(1);
+    });
+  });
+});
+
 bootstrap().catch((error) => {
   console.error('Failed to start server:', error);
   process.exit(1);
+});
+
+process.on('unhandledRejection', (error) => {
+  console.error('Unhandled promise rejection:', error);
+  shutdown('unhandledRejection', 1).catch((shutdownError) => {
+    console.error('Forced shutdown after unhandled rejection:', shutdownError);
+    process.exit(1);
+  });
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('Uncaught exception:', error);
+  shutdown('uncaughtException', 1).catch((shutdownError) => {
+    console.error('Forced shutdown after uncaught exception:', shutdownError);
+    process.exit(1);
+  });
 });

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,22 +1,17 @@
-# Build stage: compile the React application
 FROM node:20-alpine AS build
 
 WORKDIR /app
 
 COPY package*.json ./
-# Use npm install because the project does not commit a package-lock.json
-# which makes npm ci fail.
 RUN npm install
 
 COPY . .
 
-# Allow the API URL to be injected at build time
 ARG REACT_APP_API_URL
 ENV REACT_APP_API_URL=${REACT_APP_API_URL}
 
 RUN npm run build
 
-# Production stage: serve the static files with Nginx
 FROM nginx:1.27-alpine AS production
 
 COPY --from=build /app/build /usr/share/nginx/html

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,34 +10,11 @@
       content="Destination Health - Your Health Made Easy. Sign up to book appointments with family doctors and manage your health efficiently."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
     <title>Destination Health</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,2 @@
-# https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:


### PR DESCRIPTION
## Summary
- remove inline comments from Dockerfiles, SQL schema, and public assets to match production expectations
- add graceful shutdown handling for the backend server including signal, rejection, and exception hooks
- clean upload middleware comment to keep source comment free

## Testing
- REACT_APP_API_URL=http://localhost:5001 npm --prefix frontend run build
- CI=true npm --prefix frontend test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_b_68e4d932e7248322afd7f65edcff8594